### PR TITLE
Fix make command for docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ web:
 	yarn workspace @app/web dev --port 3000
 
 docs:
-	yarn workspace @app/docs start --port 3001
+	yarn workspace @app/base-docs dev --port 3001
 
 bridge:
 	yarn workspace @app/bridge dev --port 3002


### PR DESCRIPTION
**What changed? Why?**
Running `make docs` does not work because @app/docs does not exist. It seems this may have been an oversight in the migration. I converted the command from:
`yarn workspace @app/docs start --port 3001` to `yarn workspace @app/base-docs dev --port 3001`

**Notes to reviewers**


**How has it been tested?**

- Run `make docs` successfully
- Run `make` successfully