### PR TITLE
Use watch/onSettled to set NFT status

### DIFF
--- a/apps/base-docs/src/components/CafeUnitTest/index.jsx
+++ b/apps/base-docs/src/components/CafeUnitTest/index.jsx
@@ -76,6 +76,10 @@ export default function CafeUnitTest({ deployment, nftNum }) {
     abi: deployment.abi,
     functionName: 'owners',
     args: [useAccount()?.address],
+    watch: true,
+    onSettled(data) {
+      setHasPin(!!data);
+    },
   });
 
   // Test Contract Function


### PR DESCRIPTION
**What changed? Why?**
Updated the Cafe component to use watch/onSettled for a more reliable state update than the previous useEffect hook. 

**Notes to reviewers**


**How has it been tested?**
Manually