### PR TITLE
Remove confusing link

### DIFF
--- a/apps/base-docs/base-camp/docs/events/hardhat-events-sbs.md
+++ b/apps/base-docs/base-camp/docs/events/hardhat-events-sbs.md
@@ -264,7 +264,7 @@ Existing services such as [The Graph] allow you to index and create GraphQL endp
 - the ability to simply query one particular endpoint to get all the information you need
 - your users will pay less gas costs due to the minimization of storage usage in your contract
 
-But storing all of the information within the smart contract and relying fully on it to access data can create more complexity, since not all of the data is directly query-able. Thus, you can consider a system such as [Liquity] to store all of the information in the smart contract. The benefits of this approach include:
+But storing all of the information within the smart contract and relying fully on it to access data can create more complexity, since not all of the data is directly query-able. The benefits of this approach include:
 
 - your application requires only the smart contract address to access all of the required data
 - there are fewer dependencies involved, which makes this approach more crypto native in the sense that everything is in the blockchain (but, storing all the data in the blockchain will cause higher gas costs)
@@ -283,4 +283,3 @@ Now that you have a solid grasp of events and their versatile applications, you 
 
 [events]: https://docs.soliditylang.org/en/latest/contracts.html#events
 [The Graph]: https://thegraph.com/
-[Liquity]: https://www.liquity.org/


### PR DESCRIPTION


**What changed? Why?**

Link to Liquity didn't support its usage in this documentation. Perhaps the link was introduced in error, or potentially the domain name has become something else.

**Notes to reviewers**

**How has it been tested?**

It's documentation. I read it.

**Does this PR add a new token to the bridge?**

- [x] No, this PR does not add a new token to the bridge
- [ ] I've confirmed this token doesn't use a bridge override
- [ ] I've confirmed this token is an OptimismMintableERC20

Please include evidence of both confirmations above for your reviewers.
