### PR TITLE
Fix incorrect linking to sepolia.basescan

### DIFF
--- a/apps/web/src/components/SearchAddressInput/index.tsx
+++ b/apps/web/src/components/SearchAddressInput/index.tsx
@@ -2,11 +2,9 @@ import { useCallback, useEffect, useState } from 'react';
 import Input from 'apps/web/src/components/Input';
 import useBaseEnsName from 'apps/web/src/hooks/useBaseEnsName';
 import { Address, isAddress } from 'viem';
-import { useEnsAddress } from 'wagmi';
-import { BaseName } from '@coinbase/onchainkit/identity';
+import { useAccount, useEnsAddress } from 'wagmi';
 import { isBasename, isEnsName } from 'apps/web/src/utils/usernames';
 import { USERNAME_L2_RESOLVER_ADDRESSES } from 'apps/web/src/addresses/usernames';
-import useBasenameChain from 'apps/web/src/hooks/useBasenameChain';
 import { Icon } from 'apps/web/src/components/Icon/Icon';
 import { truncateMiddle } from 'libs/base-ui/utils/string';
 import Link from 'next/link';
@@ -31,12 +29,13 @@ export default function SearchAddressInput({ onChange }: SearchAddressInputProps
   /* 2. User enters an Basename */
   const validBasename = isBasename(value);
 
-  const { basenameChain } = useBasenameChain(value as BaseName);
+  const { chain: basenameChain } = useAccount();
+  const resolverAddress = basenameChain?.id ? USERNAME_L2_RESOLVER_ADDRESSES[basenameChain.id] : '0x';
 
   const { data: basenameAddress, isLoading: basenameAddressIsLoading } = useEnsAddress({
     name: value,
-    universalResolverAddress: USERNAME_L2_RESOLVER_ADDRESSES[basenameChain.id],
-    chainId: basenameChain.id,
+    universalResolverAddress: resolverAddress,
+    chainId: basenameChain?.id,
     query: {
       enabled: validBasename,
       retry: false,
@@ -60,8 +59,8 @@ export default function SearchAddressInput({ onChange }: SearchAddressInputProps
   const showUsername = valueIsAddress && !!username;
 
   // Explorer url & name
-  const baseBlockExplorerUrl = basenameChain.blockExplorers?.default.url;
-  const baseBlockExplorerName = basenameChain.blockExplorers?.default.name;
+  const baseBlockExplorerUrl = basenameChain?.blockExplorers?.default.url;
+  const baseBlockExplorerName = basenameChain?.blockExplorers?.default.name;
 
   // Final address
   const finalAddress = basenameAddress ?? ensAddress ?? value;


### PR DESCRIPTION
**What changed? Why?**
When a user is sending a name to a plain `0x..` address or an L1 ens name, we incorrectly set the `baseNameChain` as sepolia 

This PR makes it so that we always infer the chain from the connected account instead of from the ens name.

<img width="1009" alt="Screenshot 2024-08-21 at 11 44 10 PM" src="https://github.com/user-attachments/assets/21a4dd41-40c8-4f62-b488-b75b2b786d49">

**Notes to reviewers**

**How has it been tested?**
