### PR TITLE
Add error details for logging

### DIFF
--- a/apps/web/app/AppProviders.tsx
+++ b/apps/web/app/AppProviders.tsx
@@ -105,7 +105,10 @@ export default function AppProviders({ children }: AppProvidersProps) {
     }
   }, []);
 
-  const handleLogError = useCallback((err: Error) => logger.error(err), []);
+  const handleLogError = useCallback(
+    (err: Error) => logger.error('Cookie manager provider error', err),
+    [],
+  );
 
   useSprig(sprigEnvironmentId);
   return (

--- a/apps/web/contexts/Errors.tsx
+++ b/apps/web/contexts/Errors.tsx
@@ -45,7 +45,7 @@ export default function ErrorsProvider({ children, context }: ErrorsProviderProp
         console.log('--------------------------------------\n');
         return;
       } else {
-        logger.error(`Error caught with message: "${message}"`, {
+        logger.error(`Error caught with message: "${message}"`, error, {
           context: fullContext,
           message: message,
         });

--- a/apps/web/pages/api/basenames/metadata/[tokenId].ts
+++ b/apps/web/pages/api/basenames/metadata/[tokenId].ts
@@ -46,7 +46,7 @@ export default async function GET(request: Request) {
       functionName: 'name',
     });
   } catch (error) {
-    logger.error('Error getting token metadata', { error });
+    logger.error('Error getting token metadata', error);
   }
 
   // Premints are hardcoded, the list will reduce when/if they get claimed

--- a/apps/web/pages/api/basenames/talentprotocol/[address].ts
+++ b/apps/web/pages/api/basenames/talentprotocol/[address].ts
@@ -29,7 +29,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return res.status(200).json(data);
     }
   } catch (error) {
-    logger.error('error getting talent protocol information', { error });
+    logger.error('error getting talent protocol information', error);
   }
 
   return res.status(404).json({ error: 'address not found' });

--- a/apps/web/pages/api/checkNftProof/index.ts
+++ b/apps/web/pages/api/checkNftProof/index.ts
@@ -20,7 +20,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return res.status(200).json({ result: proof });
     }
   } catch (error) {
-    logger.error(error);
+    logger.error('error getting message', error);
   }
 
   return res.status(404).json({ error: 'address is not eligible for the nft' });

--- a/apps/web/pages/api/decorators.ts
+++ b/apps/web/pages/api/decorators.ts
@@ -36,10 +36,17 @@ export function withTimeout(
     } catch (error) {
       if (error instanceof Error) {
         if (error.message === 'Request timed out') {
-          logger.error('Request timed out');
+          logger.error('Request timed out', error, {
+            endpoint_url: req.url,
+            params: req.query,
+          });
           return res.status(408).json({ error: 'Request timed out' });
         }
       }
+      logger.error('Error in withTimeout', error, {
+        endpoint_url: req.url,
+        params: req.query,
+      });
       return res.status(500).json({ error: 'Something went wrong' });
     }
   };

--- a/apps/web/pages/api/name/[alreadyClaimedName].ts
+++ b/apps/web/pages/api/name/[alreadyClaimedName].ts
@@ -61,7 +61,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse<ApiResponse>) {
     res.status(200).json({ suggestion: JSON.parse(suggestion.response) as string[] });
   } catch (e) {
     if (e instanceof Error) {
-      logger.error('error generating sugestions', { error: e });
+      logger.error('error generating sugestions', e);
       res.status(500).json({ error: `failed to generate suggestions` });
     }
   }

--- a/apps/web/pages/api/paymaster/index.ts
+++ b/apps/web/pages/api/paymaster/index.ts
@@ -35,7 +35,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return res.json({ result });
     }
   } catch (e) {
-    logger.error('error validating paymaster', { error: e });
+    logger.error('error validating paymaster', e);
     return res.status(500).json({ error: 'something went wrong validating ' });
   }
 }

--- a/apps/web/pages/api/proofs/baseEthHolders/index.ts
+++ b/apps/web/pages/api/proofs/baseEthHolders/index.ts
@@ -40,7 +40,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     if (error instanceof ProofsException) {
       return res.status(error.statusCode).json({ error: error.message });
     }
-    logger.error(error);
+    logger.error('error getting proofs for baseEthHolders', error);
   }
 
   // If error is not an instance of Error, return a generic error message

--- a/apps/web/pages/api/proofs/bns/index.ts
+++ b/apps/web/pages/api/proofs/bns/index.ts
@@ -41,7 +41,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     if (error instanceof ProofsException) {
       return res.status(error.statusCode).json({ error: error.message });
     }
-    logger.error('error getting proofs for bns discount', { error });
+    logger.error('error getting proofs for bns discount', error);
   }
 
   // If error is not an instance of Error, return a generic error message

--- a/apps/web/pages/api/proofs/cb1/index.ts
+++ b/apps/web/pages/api/proofs/cb1/index.ts
@@ -56,10 +56,10 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     );
     return res.status(200).json(result);
   } catch (error) {
+    logger.error('error getting proofs for cb1 discount', error);
     if (error instanceof ProofsException) {
       return res.status(error.statusCode).json({ error: error.message });
     }
-    logger.error('error getting proofs for cb1 discount', { error });
   }
 
   // If error is not an instance of Error, return a generic error message

--- a/apps/web/pages/api/proofs/cbid/index.ts
+++ b/apps/web/pages/api/proofs/cbid/index.ts
@@ -43,7 +43,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     if (error instanceof ProofsException) {
       return res.status(error.statusCode).json({ error: error.message });
     }
-    logger.error('error getting proofs for cbid discount', { error });
+    logger.error('error getting proofs for cbid discount', error);
   }
   // If error is not an instance of Error, return a generic error message
   return res.status(500).json({ error: 'An unexpected error occurred' });

--- a/apps/web/pages/api/proofs/coinbase/index.ts
+++ b/apps/web/pages/api/proofs/coinbase/index.ts
@@ -66,7 +66,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     if (error instanceof ProofsException) {
       return res.status(error.statusCode).json({ error: error.message });
     }
-    logger.error('error getting proofs for cb1 discount', { error });
+    logger.error('error getting proofs for cb1 discount', error);
   }
 
   // If error is not an instance of Error, return a generic error message

--- a/apps/web/pages/api/proofs/earlyAccess/index.ts
+++ b/apps/web/pages/api/proofs/earlyAccess/index.ts
@@ -41,7 +41,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     if (error instanceof ProofsException) {
       return res.status(error.statusCode).json({ error: error.message });
     }
-    logger.error('error getting proofs for earlyAccess', { error });
+    logger.error('error getting proofs for earlyAccess', error);
   }
   // If error is not an instance of Error, return a generic error message
   return res.status(500).json({ error: 'An unexpected error occurred' });

--- a/apps/web/pages/api/registry/entries.ts
+++ b/apps/web/pages/api/registry/entries.ts
@@ -51,7 +51,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {
     await kv.incr(`stat:requests.${pageKey}`);
   } catch (error) {
-    logger.error('error getting registry entries', { error });
+    logger.error('error getting registry entries', error);
   }
   // Set caching headers
   res.setHeader('Cache-Control', 's-maxage=300, stale-while-revalidate');

--- a/apps/web/pages/api/registry/featured.ts
+++ b/apps/web/pages/api/registry/featured.ts
@@ -22,7 +22,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {
     await kv.incr(`stat:requests.${pageKey}`);
   } catch (error) {
-    logger.error('error getting featured registry entries', { error });
+    logger.error('error getting featured registry entries', error);
   }
 
   // Set caching headers

--- a/apps/web/scripts/helpers/getAvatarUri.js
+++ b/apps/web/scripts/helpers/getAvatarUri.js
@@ -170,7 +170,7 @@ async function getAvatarUri(address, uri, provider) {
           }
           return `${baseUrl}/${id}`;
         } catch (e) {
-          logger.error('error getting avatar URI', { error });
+          logger.error('error getting avatar URI', error);
           return null;
         }
       }

--- a/apps/web/src/cdp/api/cb-gpt.ts
+++ b/apps/web/src/cdp/api/cb-gpt.ts
@@ -51,7 +51,7 @@ export async function queryCbGpt(query: CbGptQuery): Promise<QueryCbGptResponse>
       `Unexpected error: ${response.statusText}, Response: ${JSON.stringify(errorResponse)}`,
     );
   } catch (error) {
-    logger.error('Error querying cb-gpt:', { error });
+    logger.error('Error querying cb-gpt:', error);
     throw error;
   }
 }

--- a/apps/web/src/cdp/api/get_linked_addresses.ts
+++ b/apps/web/src/cdp/api/get_linked_addresses.ts
@@ -43,7 +43,7 @@ export async function getLinkedAddresses(address: string): Promise<LinkedAddress
 
     throw new Error(`Unexpected error: ${response.statusText}, Response: ${errorResponse}`);
   } catch (error) {
-    logger.error('Error fetching linked addresses:', { error });
+    logger.error('Error fetching linked addresses:', error);
     throw error;
   }
 }

--- a/apps/web/src/utils/logger.ts
+++ b/apps/web/src/utils/logger.ts
@@ -71,7 +71,26 @@ class CustomLogger {
     this.log('warn', message, meta);
   }
 
-  public error(message: string, meta?: Record<string, unknown>) {
+  public error(message: string, error: Error | unknown, meta?: Record<string, unknown>) {
+    var e;
+    if (error instanceof Error) {
+      e = {
+        name: error.name,
+        cause: error.cause,
+        message: error.message,
+        stack: error.stack,
+      };
+    } else {
+      e = {
+        message: JSON.stringify(error),
+      };
+    }
+    if (error) {
+      this.log('error', message, {
+        ...meta,
+        error: e,
+      });
+    }
     this.log('error', message, meta);
   }
 

--- a/apps/web/src/utils/metrics.ts
+++ b/apps/web/src/utils/metrics.ts
@@ -53,19 +53,19 @@ class CustomMetricLogger {
         body: JSON.stringify(payload),
       });
     } catch (error) {
-      logger.error('Failed to send metrics to Datadog', { error });
+      logger.error('Failed to send metrics to Datadog', error);
     }
   }
 
   public sendMetric(metric: Metric) {
     this.sendToDatadog([metric]).catch((error) => {
-      logger.error('Failed to send metrics to Datadog', { error });
+      logger.error('Failed to send metrics to Datadog', error);
     });
   }
 
   public sendMetrics(metrics: Metric[]) {
     this.sendToDatadog(metrics).catch((error) => {
-      logger.error('Failed to send metrics to Datadog', { error });
+      logger.error('Failed to send metrics to Datadog', error);
     });
   }
 }

--- a/apps/web/src/utils/paymasterSponsor.ts
+++ b/apps/web/src/utils/paymasterSponsor.ts
@@ -116,7 +116,7 @@ export async function willSponsor({
     }
     return true;
   } catch (e) {
-    logger.error(`willSponsor check failed: ${e}`);
+    logger.error(`willSponsor check failed:`, e);
     return false;
   }
 }

--- a/apps/web/src/utils/proofs/sybil_resistance.ts
+++ b/apps/web/src/utils/proofs/sybil_resistance.ts
@@ -220,7 +220,7 @@ export async function sybilResistantUsernameSigning(
       expires: EXPIRY,
     };
   } catch (error) {
-    logger.error('error while getting sybilResistant basename signature', { error });
+    logger.error('error while getting sybilResistant basename signature', error);
     if (error instanceof Error) {
       throw new ProofsException(error.message, 500);
     }

--- a/apps/web/src/utils/usernames.ts
+++ b/apps/web/src/utils/usernames.ts
@@ -601,7 +601,7 @@ export async function getBasenameAvailable(name: string, chain: Chain): Promise<
     });
     return available;
   } catch (error) {
-    logger.error('Error checking name availability:', { error });
+    logger.error('Error checking name availability:', error);
     throw error;
   }
 }


### PR DESCRIPTION
**What changed? Why?**
Updating error logging so that it checks for the error object.

If we are sending an error instance (anything that extends error), then it will search for cause and stack to make it easier to debug.

If we are sending anything elsxe, it will try to get the most information by stringifying the object.

**Notes to reviewers**

**How has it been tested?**
local test:
![Screenshot 2024-08-28 at 10 02 02 AM](https://github.com/user-attachments/assets/b9c43bef-c663-4429-8d1f-49726751e16d)
