### PR TITLE
chore: Update pinata package to pinata-web3

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -42,7 +42,7 @@
     "node-fetch": "^3.3.0",
     "permissionless": "^0.1.41",
     "pg": "^8.12.0",
-    "pinata": "^0.4.0",
+    "pinata-web3": "^0.4.1",
     "react": "^18.2.0",
     "react-blockies": "^1.4.1",
     "react-copy-to-clipboard": "^5.1.0",


### PR DESCRIPTION
**What changed? Why?**

I've updated the Pinata SDK package to use the [`pinata-web3`](https://github.com/PinataCloud/pinata-web3) instead of the original SDK which no longer supports IPFS

**Notes to reviewers**

This is a direct fork of the original Pinata SDK that was originally included in the app 

**How has it been tested?**

I have not tested this app specifically but the `pinata-web3` package is working exactly as `pinata@v0.4.0`
