### PR TITLE
Fix CSS Display Property in Banner Styles

### DIFF
--- a/apps/base-docs/src/components/Banner/styles.module.css
+++ b/apps/base-docs/src/components/Banner/styles.module.css
@@ -47,7 +47,7 @@
 }
 
 .bannerSpacer {
-  display: hidden;
+  display: none;
   font-size: 0.75rem;
 }
 


### PR DESCRIPTION
**Description:**

**What changed? Why?**
Replaced `display: hidden;` with `display: none;` in the `.bannerSpacer` class to ensure proper rendering and alignment of the banner component across all screen sizes. This change improves CSS consistency and resolves potential issues with unsupported `hidden` value.

**Notes to reviewers**
Verify that the `.bannerSpacer` behaves as expected in both mobile and desktop views.
Confirm that the change does not introduce visual regressions in the banner layout.

**How has it been tested?**
- Manually tested in different screen resolutions to ensure proper display behavior.
- Confirmed that the `.bannerSpacer` is not visible when `display: none;` is applied.

Please review the changes and let me know if any additional changes are needed.

