### PR TITLE
fix: center contributor list on small screens

### DIFF
--- a/apps/web/src/components/CoreContributors/CoreContributors.tsx
+++ b/apps/web/src/components/CoreContributors/CoreContributors.tsx
@@ -15,7 +15,7 @@ const avatarCssStyle = {
 
 export default async function CoreContributors() {
   return (
-    <div className="flex flex-row flex-wrap items-start gap-3 bg-black pt-12">
+    <div className="flex flex-row flex-wrap items-start justify-center gap-3 bg-black pt-12 lg:justify-start">
       {owners?.length > 0 &&
         owners.map((owner) => {
           const filename = owner.filename ?? '';


### PR DESCRIPTION
**What changed? Why?**
Centered the Contributor List on small screens while keeping left-alignment for larger screens.

Addresses issue #1205, improving visual balance and user experience on mobile devices.

**Notes to reviewers**
Verify alignment behavior on various screen sizes.

**How has it been tested?**
Tested responsiveness across multiple screen sizes to ensure the list centers on smaller screens and remains left-aligned on larger displays.

**Screenshots**

**Before**
<div style="display: flex; gap: 10px;">
<img src="https://github.com/user-attachments/assets/3123d35d-9788-46af-b6da-edc56234750d" alt="Left-aligned on larger screen" width="48%" />
<img src="https://github.com/user-attachments/assets/5fa5767c-c22f-4d10-bbf5-0a61ef1dd014" alt="Left-aligned on larger screen" width="48%" />
</div>


**After**

<div style="display: flex; gap: 10px;">
<img src="https://github.com/user-attachments/assets/7c20c38c-1127-4c7e-9940-06a83cb7e1d3" alt="Centered on small screen" width="48%" />
<img src="https://github.com/user-attachments/assets/d6977300-03a9-4153-b7ce-d0b4e82c5b6b" alt="Centered on small screen" width="48%" />
</div>