### PR TITLE
chore: add Russian and Ukrainian translation of "Base is for everyone" on the homepage

### DIFF
--- a/apps/web/src/components/base-org/root/SlidingTextSection/index.tsx
+++ b/apps/web/src/components/base-org/root/SlidingTextSection/index.tsx
@@ -8,7 +8,7 @@ import { CSSProperties, useRef } from 'react';
 export default function SlidingTextSection() {
   const containerRef = useRef<HTMLDivElement>(null);
 
-  const text = ' Base is for everyone - بایس للجمیع - Base es para todos - 基地适合所有人 - La Base è per tutti - Base est pour tout le monde - Base ni ya kila mtu - Base yɛ ma obiara - Base nye amesiame tɔ - Base ji he ni mɔ fɛɛ mɔ yɔɔ - Бейз для каждого - Бейз для кожного ';
+  const text = ' Base is for everyone - بایس للجمیع - Base es para todos - 基地适合所有人 - La Base è per tutti - Base est pour tout le monde - Base ni ya kila mtu - Base yɛ ma obiara - Base nye amesiame tɔ - Base ji he ni mɔ fɛɛ mɔ yɔɔ - Бейз для каждого - Бейз для кожного - ';
 
 
   const containerClasses = classNames(


### PR DESCRIPTION
**What changed? Why?**
Adding Russian and Ukrainian to the "Base is for everyone" slider on the homepage