### PR TITLE
fix: center contributor list on small screens

### DIFF
--- a/apps/web/src/components/CoreContributors/CoreContributors.tsx
+++ b/apps/web/src/components/CoreContributors/CoreContributors.tsx
@@ -15,7 +15,7 @@ const avatarCssStyle = {
 
 export default async function CoreContributors() {
   return (
-    <div className="flex flex-row flex-wrap items-start gap-3 bg-black pt-12">
+    <div className="flex flex-row flex-wrap items-start justify-center gap-3 bg-black pt-12">
       {owners?.length > 0 &&
         owners.map((owner) => {
           const filename = owner.filename ?? '';


### PR DESCRIPTION
Fixes #1205

**What changed? Why?**
- Added `justify-center` class to the contributors list container
- This change centers the avatar list on mobile devices, improving user experience on small screens
- The change is minimal and only affects CSS styles through Tailwind classes

**Notes to reviewers**
- The change only affects visual presentation, without changing any logic
- Only one CSS class added for centering through Tailwind
- Solution is simple and requires no additional dependencies

**How has it been tested?** 
- Visually verified on mobile screen resolution
- Contributors list is now centered on all screen sizes
- Existing functionality (links, avatars) works as before