### PR TITLE
Update 0_deploy-with-tenderly.md

### DIFF
--- a/apps/base-docs/tutorials/docs/0_deploy-with-tenderly.md
+++ b/apps/base-docs/tutorials/docs/0_deploy-with-tenderly.md
@@ -417,4 +417,4 @@ For more information on the Tenderly full-stack infrastructure, check out the fo
 
 - [Documentation](https://docs.tenderly.co/)
 - [Blog](https://blog.tenderly.co/)
-- [Twitter](https://twitter.com/TenderlyApp)
+- [Twitter](https://x.com/TenderlyApp)


### PR DESCRIPTION
What changed & Why?
Updated Twitter URL to match the format used in other documentation links:

- [Twitter] (https://twitter.com/TenderlyApp)
+ [Twitter] (https://x.com/TenderlyApp)

This change maintains consistency with other X/Twitter links across the documentation.
Testing: ✅ Link works correctly
