### PR TITLE
docs: Fix potential underflow issue in balance calculation

### DIFF
--- a/apps/base-docs/base-learn/docs/minimal-tokens/minimal-token-sbs.md
+++ b/apps/base-docs/base-learn/docs/minimal-tokens/minimal-token-sbs.md
@@ -129,12 +129,11 @@ Instead, the transaction is reverting because of the built-in overflow/underflow
 
 ```Solidity
 function transfer(address _to, uint _amount) public {
-    int newSenderBalance = int(balances[msg.sender] - _amount);
-    if (newSenderBalance < 0) {
-        revert InsufficientTokens(newSenderBalance);
+    if (balances[msg.sender] < _amount) {
+        revert InsufficientTokens(balances[msg.sender]);
     }
 
-    balances[msg.sender] = uint(newSenderBalance);
+    balances[msg.sender] -= _amount;
     balances[_to] += _amount;
 }
 ```


### PR DESCRIPTION
**What changed? Why?**

I noticed that `newSenderBalance` was being calculated as an `int`, which doesn't make sense since `balances[msg.sender]` and `_amount` are `uint`. This could lead to an underflow issue in older Solidity versions, resulting in incorrect behavior (e.g., very large numbers).  

Here’s what I changed:  
1. Removed the unnecessary `int` casting, as it doesn’t solve the underflow problem.  
2. Added a check `if (balances[msg.sender] < _amount)` to prevent underflow.  
3. Simplified the logic: now we just check if the sender has enough tokens and proceed with the transfer if they do.  

**Notes to reviewers**

This is important because:  
- In Solidity 0.8.0+, underflow/overflow is handled automatically, but older versions are still vulnerable.  
- Using `int` for `uint` values is not a good practice and can introduce unnecessary complexity and bugs.  