### PR TITLE
Fix logical error in requireAddEvenNumbers function

### DIFF
--- a/apps/base-docs/base-learn/docs/control-structures/control-structures.md
+++ b/apps/base-docs/base-learn/docs/control-structures/control-structures.md
@@ -178,7 +178,7 @@ For example:
 function requireAddEvenNumbers(uint _first, uint _second) public pure returns (uint) {
     // Legacy pattern, do not use
     require(_first % 2 == 0, "First number is not even");
-    require(_second % 2 != 0, "Second number is not even");
+    require(_second % 2 == 0, "Second number is not even");
 
     return _first + _second;
 }


### PR DESCRIPTION
Fix logical error in requireAddEvenNumbers function
File: apps/base-docs/base-learn/docs/control-structures/control-structures.md

Change:
- Old: require(_second % 2 != 0, "Second number is not even");
- New: require(_second % 2 == 0, "Second number is not even");

Reason:
The current condition checks for odd numbers (!= 0) while the error message and function name indicate it should check for even numbers. Changed to check for even numbers (== 0) to align with function's purpose and maintain consistency with other examples.