### PR TITLE
correction index.tsx

### DIFF
--- a/apps/web/src/components/Basenames/UsernameProfileCasts/index.tsx
+++ b/apps/web/src/components/Basenames/UsernameProfileCasts/index.tsx
@@ -2,7 +2,7 @@
 
 import { useUsernameProfile } from 'apps/web/src/components/Basenames/UsernameProfileContext';
 import UsernameProfileSectionTitle from 'apps/web/src/components/Basenames/UsernameProfileSectionTitle';
-import NeymarCast from 'apps/web/src/components/NeymarCast';
+import NeynarCast from 'apps/web/src/components/NeynarCast';
 import useReadBaseEnsTextRecords from 'apps/web/src/hooks/useReadBaseEnsTextRecords';
 
 export default function UsernameProfileCasts() {
@@ -21,7 +21,7 @@ export default function UsernameProfileCasts() {
       <ul className="mt-6 grid grid-cols-1 gap-8 md:grid-cols-2">
         {casts.map((cast) => (
           <li key={cast}>
-            <NeymarCast identifier={cast} type="url" />
+            <NeynarCast identifier={cast} type="url" />
           </li>
         ))}
       </ul>


### PR DESCRIPTION
**What changed? Why?**
All references to “NeymarCast” were changed to “NeynarCast” to maintain consistent naming that aligns with the neynar.com domain.