### PR TITLE
Fix uninitialized tracer variable

### DIFF
--- a/apps/web/tracer/initialize.js
+++ b/apps/web/tracer/initialize.js
@@ -33,4 +33,4 @@ const initTracer = () => {
   return tracer;
 };
 
-tracer = initTracer();
+const tracer = initTracer();


### PR DESCRIPTION
**What changed? Why?**
Fix uninitialized tracer variable. Declaring `const tracer = initTracer();` prevents reference errors and clarifies usage.

