### PR TITLE
Update Documentation

### DIFF
--- a/apps/base-docs/tutorials/docs/1_2_smart-wallet-and-eoa-with-onchainkit.md
+++ b/apps/base-docs/tutorials/docs/1_2_smart-wallet-and-eoa-with-onchainkit.md
@@ -102,7 +102,7 @@ Open `src/components/WalletWrapper.tsx`, and `src/wagmi.ts`. Take a quick look a
 
 You can customize this by making some changes to `wagmi.ts`.
 
-Start with `wagmi.ts`. Update it import the [RainbowKit] connectors for the wallets you want to use (We just picked the ones a the end of the supported list. Do your homework on which wallets to support!):
+Start with `wagmi.ts`. Update it import the [RainbowKit] connectors for the wallets you want to use (We just picked the ones at the end of the supported list. Do your homework on which wallets to support!):
 
 ```tsx
 import { http, createConfig } from 'wagmi';

--- a/apps/base-docs/tutorials/docs/1_3_smart-wallet-and-rainbowkit.md
+++ b/apps/base-docs/tutorials/docs/1_3_smart-wallet-and-rainbowkit.md
@@ -8,7 +8,6 @@ keywords:
     JSON RPC,
     RainbowKit,
     OnchainKit,
-    frontend,
     Next.js,
     Base,
     blockchain development,


### PR DESCRIPTION
Fixed the typo "a" to "at" for clarity.

Removed duplicate entry for "frontend" to maintain a clean and concise keywords list.