### PR TITLE
chore: fix incorrect string method usage in event name sanitization

### DIFF
--- a/libs/base-ui/contexts/Analytics.tsx
+++ b/libs/base-ui/contexts/Analytics.tsx
@@ -35,7 +35,7 @@ export default function AnalyticsProvider({ children, context }: AnalyticsProvid
   const fullContext = [previousContext, context].filter((c) => !!c).join('_');
   const logEventWithContext = useCallback(
     (eventName: string, action: ActionType, eventData?: CCAEventData) => {
-      const sanitizedEventName = eventName.toLocaleLowerCase();
+      const sanitizedEventName = eventName.toLowerCase();
       if (typeof window === 'undefined') return;
 
       if (isDevelopment) {


### PR DESCRIPTION
**What changed? Why?**  
Replaced `toLocaleLowerCase()` with `toLowerCase()` when normalizing event names. Locale-specific behavior isn’t needed here, and `toLowerCase()` ensures consistent behavior across environments.  

**Notes to reviewers**  
This change prevents potential inconsistencies when handling event names in different locales. Let me know if there’s any specific case I might have overlooked.  

**How has it been tested?**  
Manually tested by logging event names before and after the change to confirm they remain consistent. No regressions observed.