### PR TITLE
chore: fix incorrect Next.js imports for Image and Link

### DIFF
--- a/apps/web/app/(base-org)/frames/names/page.tsx
+++ b/apps/web/app/(base-org)/frames/names/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
-import Image from 'apps/web/node_modules/next/image';
-import Link from 'apps/web/node_modules/next/link';
+import Image from 'next/image';
+import Link from 'next/link';
 import initialFrameImage from 'apps/web/pages/api/basenames/frame/assets/initial-image.png';
 import { initialFrame } from 'apps/web/pages/api/basenames/frame/frameResponses';
 


### PR DESCRIPTION
**What changed? Why?**  
Replaced `apps/web/node_modules/next/image` and `apps/web/node_modules/next/link` with proper imports from `next/image` and `next/link`. This ensures compatibility with Next.js best practices and avoids potential module resolution issues.  

**Notes to reviewers**  
Let me know if there was a specific reason for the previous import paths—happy to adjust if needed.  

**How has it been tested?**  
Tested locally by running the app and verifying that the Image and Link components work as expected without errors.