### PR TITLE
Remove the Docker build of the bridge image

### DIFF
--- a/.codeflow.yml
+++ b/.codeflow.yml
@@ -15,10 +15,6 @@ build:
         name: docs
         path: ./apps/base-docs/Dockerfile
         architecture: amd64
-    - BaldurECR:
-        name: bridge
-        path: ./apps/bridge/Dockerfile
-        architecture: amd64
   multi_arch: true
 
 operate:


### PR DESCRIPTION
**What changed? Why?**
We no longer deploy or use this image anymore, so remove it (it's currently failing to build).
