### PR TITLE
fix: clean up unnecessary dependencies in useCallback

### DIFF
--- a/libs/base-ui/components/Layout/Nav/Banner.tsx
+++ b/libs/base-ui/components/Layout/Nav/Banner.tsx
@@ -36,7 +36,7 @@ export default function Banner({ href, text, bannerName }: BannerProps) {
       },
       AnalyticsEventImportance.high,
     );
-  }, [logEvent, ActionType, ComponentType, AnalyticsEventImportance, bannerName]);
+  }, [logEvent, bannerName]);
 
   const hideBanner = useCallback(() => {
     setIsBannerVisible(false);


### PR DESCRIPTION
**What changed? Why?**  
Removed unnecessary dependencies (`ActionType`, `ComponentType`, `AnalyticsEventImportance`) from the `useCallback` dependency array in `linkClick`. These are imported constants and don’t change between renders, so including them was unnecessary. This prevents unnecessary re-creations of the function.  

**Notes to reviewers**  
This is a small cleanup to improve performance and ensure best practices with React hooks. Let me know if you see any edge cases I might have missed.  

**How has it been tested?**  
Manually tested by checking that the `linkClick` function still fires correctly and that React doesn’t trigger unnecessary re-renders. No functional changes expected.