### PR TITLE
fix: ecosystem filters

### DIFF
--- a/apps/web/src/components/Ecosystem/Content.tsx
+++ b/apps/web/src/components/Ecosystem/Content.tsx
@@ -45,7 +45,6 @@ const config: Record<string, string[]> = {
   ],
   onramp: ['centralized exchange', 'fiat on-ramp'],
   infra: [
-    'ai',
     'bridge',
     'data',
     'depin',


### PR DESCRIPTION
**What changed? Why?**
* removed `ai` subcategory from `infra` — prevents toggling AI filter when Infra is selected

**Notes to reviewers**

**How has it been tested?**
locally