### PR TITLE
Fixed Hyperlink Formatting in Help on Discord Page

### DIFF
--- a/apps/base-docs/docs/pages/learn/help-on-discord.md
+++ b/apps/base-docs/docs/pages/learn/help-on-discord.md
@@ -11,7 +11,7 @@ Whether you're confused about something weird in Solidity, having trouble gettin
 
 First, join the [Base Discord].
 
-Then, get help from the community, Based Advocates, and the authors of the program in the [Base Learn] channel!
+Then, get help from the community, Based Advocates, and the authors of the program in the [Base Learn Channel]!
 
 [Base Discord]: https://base.org/discord
 [Base Learn Channel]: https://discord.com/channels/1067165013397213286/1108389436644917328


### PR DESCRIPTION
### **Description:**

**What changed? Why?**  
Fixed a hyperlink issue in `apps/base-docs/docs/pages/learn/help-on-discord.md`. The original `[Base Learn] channel` formatting was incorrect, preventing the hyperlink from working properly. After adjusting the formatting to `[Base Learn Channel] `, the hyperlink now functions correctly.

**Notes to Reviewers:**  
Documentation fix. 

**How has it been tested?**

- Verified that the hyperlink is now properly rendered and clickable in the documentation.