### PR TITLE
Rename InvalidUnderscore to InvalidUnderScore in RawErrorStrings enum

### DIFF
--- a/apps/web/src/utils/frames/basenames.ts
+++ b/apps/web/src/utils/frames/basenames.ts
@@ -8,7 +8,7 @@ export enum RawErrorStrings {
   TooLong = 'Name is too long',
   DisallowedChars = 'disallowed character:',
   Invalid = 'Name is invalid',
-  InvalidUnderscore = 'underscore allowed only at start',
+  InvalidUnderScore = 'underscore allowed only at start',
 }
 
 export async function getTransactionStatus(chain: Chain, transactionId: string) {


### PR DESCRIPTION
Standardize naming convention in RawErrorStrings enum to consistent PascalCase format