### PR TITLE
fix: update dead link to Privy website

### DIFF
--- a/apps/base-docs/docs/pages/cookbook/account-abstraction/account-abstraction-on-base-using-privy-and-the-base-paymaster.mdx
+++ b/apps/base-docs/docs/pages/cookbook/account-abstraction/account-abstraction-on-base-using-privy-and-the-base-paymaster.mdx
@@ -715,9 +715,9 @@ In this article, we've explored the transformative potential of Account Abstract
 [Base Learn]: https://base.org/learn
 [Next.js]: https://nextjs.org/
 [Base Paymaster]: https://github.com/base-org/paymaster
-[Privy]: https://www.privy.dev/
+[Privy]: https://www.privy.io/
 [Alchemy's Account Kit]: https://www.alchemy.com/account-kit
-[Privy]: https://www.privy.dev/
+[Privy]: https://www.privy.io/
 [https://docs.privy.io/guide/frontend/embedded/overview]: https://docs.privy.io/guide/frontend/embedded/overview
 [Alchemy's Account Kit]: https://www.alchemy.com/account-kit
 [Privy's Quick Start]: https://docs.privy.io/guide/quickstart


### PR DESCRIPTION
## Description
Hello! I fixes a dead link in the `account-abstraction-on-base-using-privy-and-the-base-paymaster.mdx` file. The old link pointed to a non-existent page for the Privy website. It has been updated to the correct and current URL.