### PR TITLE
Fix Typographical Error in Deployment Instructions

### DIFF
--- a/apps/base-docs/docs/pages/cookbook/use-case-guides/creator/convert-farcaster-frame-to-open-frame.mdx
+++ b/apps/base-docs/docs/pages/cookbook/use-case-guides/creator/convert-farcaster-frame-to-open-frame.mdx
@@ -266,7 +266,7 @@ export const dynamic = 'force-dynamic';
 
 Repeat this process for any of the additional routes you may want to convert from Farcaster Frames to Open Frames.
 
-## Redploy your frame
+## Redeploy your frame
 
 Before redeploying your Frame check how the routes differ using the [Frame Debugger]. The frame debugger should be used to validate that your frame follows the Openframe protocol spec.
 


### PR DESCRIPTION
File Changed: deployment_instructions.md
Old Word: Redploy your frame
New Word: Redeploy your frame
Reason for Change: Corrected a typographical error to maintain professionalism and ensure clear communication.