### PR TITLE
chore(resources): Remove OCN

### DIFF
--- a/apps/web/src/components/GetStarted/GetNoticed.tsx
+++ b/apps/web/src/components/GetStarted/GetNoticed.tsx
@@ -14,14 +14,6 @@ export default async function GetNoticed() {
       </Title>
       <div className={gridClasses}>
         <ResourceCard
-          title="Onchain Content Network"
-          description="Submit your project to be viewed by millions of potential users across the network"
-          href="https://buildonbase.deform.cc/getstarted/?utm_source=dotorg&utm_medium=builderkit"
-          topLeft={<span className="font-mono">01</span>}
-          topRight={<Icon name="diagonalUpArrow" width="16px" height="16px" />}
-          classnames="bg-pink-60 border-pink-60"
-        />
-        <ResourceCard
           title="Marketing Amplification Guidelines"
           description="Use our style guide and tag @base on X and Farcaster to be eligible for amplification"
           href="https://github.com/base-org/brand-kit/blob/main/guides/editorial-style-guide.md"


### PR DESCRIPTION
**What changed? Why?**

Removes OCN from the Resources page

**Notes to reviewers**

Before:
![2025-02-24 at 11 10 00@2x](https://github.com/user-attachments/assets/f152cf85-9fad-4706-a529-58a1601db384)

After:
![2025-02-24 at 11 45 22@2x](https://github.com/user-attachments/assets/53d2cb67-568c-488e-9ce4-a8a2df292bec)


**How has it been tested?**

Localhost
