### PR TITLE
fix: Fix typo in button styles

### DIFF
--- a/apps/base-docs/docs/components/Button/index.tsx
+++ b/apps/base-docs/docs/components/Button/index.tsx
@@ -19,7 +19,7 @@ const variantStyles: Record<ButtonVariants, string> = {
   [ButtonVariants.Primary]:
     'bg-blue text-white border border-blue hover:bg-blue-80 active:bg-[#06318E]',
 
-  // White buton
+  // White button
   [ButtonVariants.Secondary]:
     'bg-white border border-white text-palette-foreground hover:bg-zinc-15 active:bg-zinc-30',
 
@@ -32,7 +32,7 @@ const sizeStyles: Record<ButtonSizes, string> = {
   // Blue button
   [ButtonSizes.Medium]: 'text-md px-4 py-2 gap-3',
 
-  // White buton
+  // White button
   [ButtonSizes.Large]: 'text-lg px-6 py-4 gap-5',
 };
 
@@ -40,7 +40,7 @@ const sizeIconRatio: Record<ButtonSizes, string> = {
   // Blue button
   [ButtonSizes.Medium]: '0.75rem',
 
-  // White buton
+  // White button
   [ButtonSizes.Large]: '1rem',
 };
 


### PR DESCRIPTION
**What changed? Why?**  
I fixed a typo in the button styles where "buton" was used instead of "button". This ensures proper spelling and consistency in the code.

**Notes to reviewers**  
Please review the changes to ensure the correct spelling of "button" in the styles. There should be no other changes to the functionality.

**How has it been tested?**  
The code was reviewed for correctness. No functional tests are needed as this change only affects the style definitions.
