### PR TITLE
Update Office Hours button

### DIFF
--- a/apps/web/src/components/GetStarted/BuildWithUsFooter.tsx
+++ b/apps/web/src/components/GetStarted/BuildWithUsFooter.tsx
@@ -34,7 +34,7 @@ export default async function BuildWithUsFooter() {
 
         <div className="flex w-full flex-col items-center justify-center gap-4 sm:w-auto sm:flex-row sm:gap-8">
           <ButtonWithLinkAndEventLogging
-            href="https://lu.ma/base-officehours/?utm_source=dotorg&medium=builderkit"
+            href="https://lu.ma/base-virtualevents/?utm_source=dotorg&medium=builderkit"
             eventName="start_building_with_us_contact_us"
             target="_blank"
             rel="noreferrer noopener"
@@ -42,7 +42,7 @@ export default async function BuildWithUsFooter() {
             size={ButtonSizes.Large}
             buttonClassNames={`${linkTextClasses} rounded-[3px]`}
           >
-            Office Hours
+            Virtual Events
           </ButtonWithLinkAndEventLogging>
           <ButtonWithLinkAndEventLogging
             href="https://docs.base.org/docs/?utm_source=dotorg&utm_medium=builderkit"


### PR DESCRIPTION
**What changed? Why?**
Updated Office Hours button to be Virtual Events button as well as Luma event page link from /base-officehours to /base-virtualevents

**Notes to reviewers**
Please confirm that the Event Logging part of the URL will be unaffected? It seems to have the same URL ending for the "View Our Docs" button too

**How has it been tested?**
We will update the Luma link from Office Hours to Virtual Events once approved or acked by approver.
