### PR TITLE
Update Office Hours tile

### DIFF
--- a/apps/web/src/components/GetStarted/Essentials.tsx
+++ b/apps/web/src/components/GetStarted/Essentials.tsx
@@ -33,9 +33,9 @@ export default async function Essentials() {
           classnames="bg-purple-60 border-purple-60"
         />
         <ResourceCard
-          title="Office Hours"
-          description="Check out our Office Hours schedule to ask your questions live"
-          href="https://lu.ma/base-officehours/?utm_source=dotorg&medium=builderkit"
+          title="Virtual Events"
+          description="Check out our Virtual Events schedule to ask your questions live"
+          href="https://lu.ma/base-virtualevents/?utm_source=dotorg&medium=builderkit"
           topLeft={<Icon name="dotGrid" color="white" />}
           classnames="bg-purple-80 border-purple-80"
         />


### PR DESCRIPTION
**What changed? Why?**
Updated Office Hours tile to be Virtual Events tile as well as Luma event page link from /base-officehours to /base-virtualevents

**Notes to reviewers**
Please confirm that the Event Logging part of the URL will be unaffected? It seems to have the same URL ending as the rest of the URLs

**How has it been tested?**
We will update the Luma link from Office Hours to Virtual Events once approved or acked by approver.
