### PR TITLE
Fix flashblock buildathon doc page to use flashblock RPC only

### DIFF
--- a/apps/base-docs/docs/pages/buildathons/2025-02-flash.mdx
+++ b/apps/base-docs/docs/pages/buildathons/2025-02-flash.mdx
@@ -18,13 +18,11 @@ Submissions are due by 2pm MNT (GMT-7) on Friday 2/28 and will be judged on clar
 
 Winners will be announced **Fri 2/28 3pm MT at the Home Base booth and on socials** — join us for free pizza and flashblocks demo
 
-**Base Sepolia RPC Endpoints**
+**Base Sepolia Flashblock RPC Endpoint**
 
 ```bash
 https://sepolia-preconf.base.org
 ```
-
-:::
 
 ## Prizes
 

--- a/apps/base-docs/docs/pages/buildathons/2025-02-flash.mdx
+++ b/apps/base-docs/docs/pages/buildathons/2025-02-flash.mdx
@@ -21,12 +21,7 @@ Winners will be announced **Fri 2/28 3pm MT at the Home Base booth and on social
 **Base Sepolia RPC Endpoints**
 
 :::code-group
-
-```bash [Full block RPC endpoint]
-https://sepolia.base.org
-```
-
-```bash [Flashblock RPC endpoint]
+```bash
 https://sepolia-preconf.base.org
 ```
 
@@ -84,12 +79,3 @@ curl https://sepolia-preconf.base.org \
   }'
 ```
 
-:::
-
-### Full Block RPC endpoint
-
-The existing RPC endpoint for interacting with full blocks is still available at:
-
-```
-https://sepolia.base.org
-```

--- a/apps/base-docs/docs/pages/buildathons/2025-02-flash.mdx
+++ b/apps/base-docs/docs/pages/buildathons/2025-02-flash.mdx
@@ -20,7 +20,6 @@ Winners will be announced **Fri 2/28 3pm MT at the Home Base booth and on social
 
 **Base Sepolia RPC Endpoints**
 
-:::code-group
 ```bash
 https://sepolia-preconf.base.org
 ```


### PR DESCRIPTION
**What changed? Why?**
Fix flashblock buildathon doc page to use flashblock RPC only

**Notes to reviewers**

**How has it been tested?**
