### PR TITLE
Update go-gasless Discord link

### DIFF
--- a/apps/base-docs/docs/pages/use-cases/go-gasless.mdx
+++ b/apps/base-docs/docs/pages/use-cases/go-gasless.mdx
@@ -397,7 +397,7 @@ This approach can greatly improve your dApp’s user experience by removing gas 
 - [simple NFT contract]
 
 [list of factory addresses]: https://docs.alchemy.com/reference/factory-addresses
-[Discord]: https://discord.gg/AaAcm4UW
+[Discord]: https://discord.com/invite/cdp
 [CDP site]: https://portal.cdp.coinbase.com/
 [Coinbase Developer Platform]: https://portal.cdp.coinbase.com/
 [UI]: https://portal.cdp.coinbase.com/products/bundler-and-paymaster


### PR DESCRIPTION


**What changed? Why?**

Updated CDP Discord link that was used. Someone used an expiring link which has now been taken by a mailscious actor.

This is the expiring link that has been hijacked: https://discord.gg/AaAcm4UW

This is where it should link to: https://discord.com/invite/cdp

**Notes to reviewers**
URGENT need to check the site for repeat instances

**How has it been tested?**
