### PR TITLE
fix: Update contract addresses

### DIFF
--- a/apps/base-docs/docs/pages/chain/base-contracts.mdx
+++ b/apps/base-docs/docs/pages/chain/base-contracts.mdx
@@ -119,9 +119,6 @@ Certain contracts are mandatory according to the [OP Stack SDK](https://stack.op
 | Proxy Admin Owner (L1)           | [0x7bB41C3008B3f03FE483B28b8DB90e19Cf07595c](https://etherscan.io/address/0x7bB41C3008B3f03FE483B28b8DB90e19Cf07595c) | 2-of-2 Nested Gnosis Safe (signers below) |
 | L1 Nested Safe Signer (Coinbase) | [0x9855054731540A48b28990B63DcF4f33d8AE46A1](https://etherscan.io/address/0x9855054731540A48b28990B63DcF4f33d8AE46A1) | Gnosis Safe                               |
 | L1 Nested Safe Signer (Optimism) | [0x9BA6e03D8B90dE867373Db8cF1A58d2F7F006b3A](https://etherscan.io/address/0x9BA6e03D8B90dE867373Db8cF1A58d2F7F006b3A) | Gnosis Safe                               |
-| Proxy Admin Owner (L2)           | [0x2304cb33d95999dc29f4cef1e35065e670a70050](https://basescan.org/address/0x2304cb33d95999dc29f4cef1e35065e670a70050) | 2-of-2 Nested Gnosis Safe (signers below) |
-| L2 Nested Safe Signer (Coinbase) | [0xd94e416cf2c7167608b2515b7e4102b41efff94f](https://basescan.org/address/0xd94e416cf2c7167608b2515b7e4102b41efff94f) | Gnosis Safe                               |
-| L2 Nested Safe Signer (Optimism) | [0x28EDB11394eb271212ED66c08f2b7893C04C5D65](https://basescan.org/address/0x28EDB11394eb271212ED66c08f2b7893C04C5D65) | Gnosis Safe                               |
 | Challenger                       | [0x6f8c5ba3f59ea3e76300e3becdc231d656017824](https://etherscan.io/address/0x6f8c5ba3f59ea3e76300e3becdc231d656017824) | 1-of-2 Smart contract                     |
 | System config owner              | [0x14536667Cd30e52C0b458BaACcB9faDA7046E056](https://etherscan.io/address/0x14536667Cd30e52C0b458BaACcB9faDA7046E056) | Gnosis Safe                               |
 | Guardian                         | [0x14536667Cd30e52C0b458BaACcB9faDA7046E056](https://etherscan.io/address/0x14536667Cd30e52C0b458BaACcB9faDA7046E056) | Gnosis Safe                               |

--- a/apps/base-docs/docs/pages/chain/base-contracts.mdx
+++ b/apps/base-docs/docs/pages/chain/base-contracts.mdx
@@ -131,7 +131,6 @@ Certain contracts are mandatory according to the [OP Stack SDK](https://stack.op
 | Batch Inbox            | [0xff00000000000000000000000000000000084532](https://sepolia.etherscan.io/address/0xff00000000000000000000000000000000084532)      | EOA (with no known private key)      |
 | Output Proposer        | [0x20044a0d104E9e788A0C984A2B7eAe615afD046b](https://sepolia.etherscan.io/address/0x20044a0d104E9e788A0C984A2B7eAe615afD046b)      | EOA managed by Coinbase Technologies |
 | Proxy Admin Owner (L1) | [0x0fe884546476dDd290eC46318785046ef68a0BA9](https://sepolia.etherscan.io/address/0x0fe884546476dDd290eC46318785046ef68a0BA9)      | Gnosis Safe                          |
-| Proxy Admin Owner (L2) | [0x20f984546476ddd290ec46318785046ef68a1cba](https://sepolia-explorer.base.org/address/0x20f984546476ddd290ec46318785046ef68a1cba) | Gnosis Safe                          |
 | Challenger             | [0xDa3037Ff70Ac92CD867c683BD807e5A484857405](https://sepolia.etherscan.io/address/0xDa3037Ff70Ac92CD867c683BD807e5A484857405)      | EOA managed by Coinbase Technologies |
 | System config owner    | [0x0fe884546476dDd290eC46318785046ef68a0BA9](https://sepolia.etherscan.io/address/0x0fe884546476dDd290eC46318785046ef68a0BA9)      | Gnosis Safe                          |
 | Guardian               | [0xA9FF930151130fd19DA1F03E5077AFB7C78F8503](https://sepolia.etherscan.io/address/0xA9FF930151130fd19DA1F03E5077AFB7C78F8503)      | EOA managed by Coinbase Technologies |

--- a/apps/base-docs/docs/pages/chain/base-contracts.mdx
+++ b/apps/base-docs/docs/pages/chain/base-contracts.mdx
@@ -134,4 +134,3 @@ Certain contracts are mandatory according to the [OP Stack SDK](https://stack.op
 | Challenger             | [0xDa3037Ff70Ac92CD867c683BD807e5A484857405](https://sepolia.etherscan.io/address/0xDa3037Ff70Ac92CD867c683BD807e5A484857405)      | EOA managed by Coinbase Technologies |
 | System config owner    | [0x0fe884546476dDd290eC46318785046ef68a0BA9](https://sepolia.etherscan.io/address/0x0fe884546476dDd290eC46318785046ef68a0BA9)      | Gnosis Safe                          |
 | Guardian               | [0xA9FF930151130fd19DA1F03E5077AFB7C78F8503](https://sepolia.etherscan.io/address/0xA9FF930151130fd19DA1F03E5077AFB7C78F8503)      | EOA managed by Coinbase Technologies |
-

--- a/apps/base-docs/docs/pages/chain/base-contracts.mdx
+++ b/apps/base-docs/docs/pages/chain/base-contracts.mdx
@@ -94,7 +94,7 @@ Certain contracts are mandatory according to the [OP Stack SDK](https://stack.op
 | DelayedWETHProxy (FDG)       | [0x489c2E5ebe0037bDb2DC039C5770757b8E54eA1F](https://sepolia.etherscan.io/address/0x489c2E5ebe0037bDb2DC039C5770757b8E54eA1F) |
 | DelayedWETHProxy (PDG)       | [0x27A6128F707de3d99F89Bf09c35a4e0753E1B808](https://sepolia.etherscan.io/address/0x27A6128F707de3d99F89Bf09c35a4e0753E1B808) |
 | DisputeGameFactoryProxy      | [0xd6E6dBf4F7EA0ac412fD8b65ED297e64BB7a06E1](https://sepolia.etherscan.io/address/0xd6E6dBf4F7EA0ac412fD8b65ED297e64BB7a06E1) |
-| FaultDisputeGame             | [0x5062792ED6A85cF72a1424a1b7f39eD0f7972a4B](https://sepolia.etherscan.io/address/0x5062792ED6A85cF72a1424a1b7f39eD0f7972a4B) |
+| FaultDisputeGame             | [0x605b4248500c0a144e39bbb04c05c539e388e222](https://sepolia.etherscan.io/address/0x605b4248500c0a144e39bbb04c05c539e388e222) |
 | L1CrossDomainMessenger       | [0xC34855F4De64F1840e5686e64278da901e261f20](https://sepolia.etherscan.io/address/0xC34855F4De64F1840e5686e64278da901e261f20) |
 | L1ERC721Bridge               | [0x21eFD066e581FA55Ef105170Cc04d74386a09190](https://sepolia.etherscan.io/address/0x21eFD066e581FA55Ef105170Cc04d74386a09190) |
 | L1StandardBridge             | [0xfd0Bf71F60660E2f608ed56e1659C450eB113120](https://sepolia.etherscan.io/address/0xfd0Bf71F60660E2f608ed56e1659C450eB113120) |
@@ -102,7 +102,7 @@ Certain contracts are mandatory according to the [OP Stack SDK](https://stack.op
 | MIPS                         | [0x47B0E34C1054009e696BaBAAd56165e1e994144d](https://sepolia.etherscan.io/address/0x47B0E34C1054009e696BaBAAd56165e1e994144d) |
 | OptimismMintableERC20Factory | [0xb1efB9650aD6d0CC1ed3Ac4a0B7f1D5732696D37](https://sepolia.etherscan.io/address/0xb1efB9650aD6d0CC1ed3Ac4a0B7f1D5732696D37) |
 | OptimismPortal               | [0x49f53e41452C74589E85cA1677426Ba426459e85](https://sepolia.etherscan.io/address/0x49f53e41452C74589E85cA1677426Ba426459e85) |
-| PermissionedDisputeGame      | [0x593D20C4c69485B95D11507239BE2C725ea2A6fD](https://sepolia.etherscan.io/address/0x593D20C4c69485B95D11507239BE2C725ea2A6fD) |
+| PermissionedDisputeGame      | [0x71ff927ee7b96f873c249093846aa292f374aef4](https://sepolia.etherscan.io/address/0x71ff927ee7b96f873c249093846aa292f374aef4) |
 | PreimageOracle               | [0x92240135b46fc1142dA181f550aE8f595B858854](https://sepolia.etherscan.io/address/0x92240135b46fc1142dA181f550aE8f595B858854) |
 | ProxyAdmin                   | [0x0389E59Aa0a41E4A413Ae70f0008e76CAA34b1F3](https://sepolia.etherscan.io/address/0x0389E59Aa0a41E4A413Ae70f0008e76CAA34b1F3) |
 | SystemConfig                 | [0xf272670eb55e895584501d564AfEB048bEd26194](https://sepolia.etherscan.io/address/0xf272670eb55e895584501d564AfEB048bEd26194) |


### PR DESCRIPTION
**What changed? Why?**
We re-deployed our Sepolia `FaultDisputeGame` and `PermissionedDisputeGame` contracts today to prepare for testnet Pectra upgrades. I also noticed we still include `L2ProxyAdminOwner` contract addresses for both mainnet and testnet which are no longer used. Those have been removed.

**Notes to reviewers**
You can confirm the new FDG and PDG contract addresses [here](https://github.com/base/contract-deployments/blob/main/sepolia/2025-02-14-upgrade-fault-proofs/addresses.json).
You can confirm the mainnet L2 Proxy admin owner is no longer valid [here](https://basescan.org/address/0x4200000000000000000000000000000000000018#readProxyContract#F6).
You can confirm the testnet L2 Proxy admin owner is no longer valid [here](https://sepolia.basescan.org/address/0x4200000000000000000000000000000000000018#readProxyContract#F6).

**How has it been tested?**
