### PR TITLE
docs: fix dead links across documentation

### DIFF
--- a/apps/base-docs/docs/pages/cookbook/nfts/thirdweb-unreal-nft-items.mdx
+++ b/apps/base-docs/docs/pages/cookbook/nfts/thirdweb-unreal-nft-items.mdx
@@ -615,8 +615,8 @@ Compile, save, and close `Canvas_HUD`. Run the game. Your car will start red, bu
 
 In this tutorial, you've learned how to set up Thirdweb's engine and use it to connect an Unreal Engine game to Base. You've also learned how to use their platform to deploy and manager your contracts. Finally, you've learned how to build game elements to allow players to collect new NFTs and use them to personalize their game items.
 
-[Base Learn]: https://base.org/learn
-[ERC-721 Tokens]: https://docs.base.org/base-learn/docs/erc-721-token/erc-721-standard-video
+[Base Learn]: https://docs.base.org/learn/welcome
+[ERC-721 Tokens]: https://docs.base.org/learn/erc-721-token/erc-721-standard-video
 [OpenZeppelin ERC-721]: https://docs.openzeppelin.com/contracts/2.x/api/token/erc721
 [OpenZeppelin]: https://www.openzeppelin.com/
 [Unreal Engine]: https://www.unrealengine.com/en-US

--- a/apps/base-docs/docs/pages/cookbook/use-case-guides/finance/access-real-world-data-chainlink.mdx
+++ b/apps/base-docs/docs/pages/cookbook/use-case-guides/finance/access-real-world-data-chainlink.mdx
@@ -39,7 +39,7 @@ In order to deploy a smart contract, you will first need a wallet. You can creat
 
 Deploying contracts to the blockchain requires a gas fee. Therefore, you will need to fund your wallet with ETH to cover those gas fees.
 
-For this tutorial, you will be deploying a contract to the Base Goerli test network. You can fund your wallet with Base Goerli ETH using one of the faucets listed on the Base [Network Faucets](https://docs.base.org/docs/chain/network-faucets) page.
+For this tutorial, you will be deploying a contract to the Base Goerli test network. You can fund your wallet with Base Goerli ETH using one of the faucets listed on the Base [Network Faucets](https://docs.base.org/chain/network-faucets) page.
 
 ## What are Chainlink Data Feeds?
 
@@ -228,6 +228,6 @@ Congratulations! You have successfully deployed and interacted with a smart cont
 
 To learn more about Oracles and using Chainlink to access real-world data within your smart contracts on Base, check out the following resources:
 
-- [Oracles](https://docs.base.org/tools/oracles)
+- [Oracles](https://docs.base.org/chain/oracles)
 - [Chainlink Data Feeds on Base](https://docs.chain.link/data-feeds/price-feeds/addresses?network=base&page=1&search=#networks)
 

--- a/apps/base-docs/docs/pages/learn/reading-and-displaying-data/useAccount.md
+++ b/apps/base-docs/docs/pages/learn/reading-and-displaying-data/useAccount.md
@@ -159,5 +159,5 @@ In this guide, you've learned how the `useAccount` hook gives you access to info
 [Wallet Connectors]: ../frontend-setup/wallet-connectors/
 [`useAccount`]: https://wagmi.sh/react/hooks/useAccount
 [hydration error]: https://nextjs.org/docs/messages/react-hydration-error
-[Introduction to Providers]: https://docs.base.org/tutorials/intro-to-providers/
+[Introduction to Providers]: https://docs.base.org/cookbook/client-side-development/introduction-to-providers
 [UseAccountReturnType]: https://wagmi.sh/react/api/hooks/useAccount#return-type


### PR DESCRIPTION
Hey! I noticed a few broken links in the docs and updated them to their correct locations