### PR TITLE
fix: fix `L1StandardBridge` import and usage in `usePrepareBridge` hook

### DIFF
--- a/apps/bridge/src/utils/hooks/usePrepareERC20DepositTo.ts
+++ b/apps/bridge/src/utils/hooks/usePrepareERC20DepositTo.ts
@@ -1,4 +1,4 @@
-import L1StandartBridge from 'apps/bridge/src/contract-abis/L1StandardBridge';
+import L1StandardBridge from 'apps/bridge/src/contract-abis/L1StandardBridge';
 import { Asset } from 'apps/bridge/src/types/Asset';
 import getConfig from 'next/config';
 import { parseUnits } from 'viem';
@@ -28,7 +28,7 @@ export function usePrepareERC20DepositTo({
       isPermittedToBridge && depositAmount !== ''
         ? publicRuntimeConfig.l1BridgeProxyAddress
         : undefined,
-    abi: L1StandartBridge,
+    abi: L1StandardBridge,
     functionName: 'depositERC20To',
     chainId: parseInt(publicRuntimeConfig.l1ChainID),
     args: [
@@ -55,7 +55,7 @@ export async function prepareERC20DepositTo({
 }: UsePrepareERC20DepositToProps) {
   return prepareWriteContract({
     address: publicRuntimeConfig.l1BridgeProxyAddress,
-    abi: L1StandartBridge,
+    abi: L1StandardBridge,
     functionName: 'depositERC20To',
     chainId: parseInt(publicRuntimeConfig.l1ChainID),
     args: [


### PR DESCRIPTION
This PR updates the L1StandardBridge import and implementation in the bridge utilities:

- Fixed import statement for L1StandardBridge
- Updated bridge configuration to use correct L1StandardBridge reference
- Ensures consistent bridge implementation across deposit functions

These changes improve the stability and correctness of the bridge integration.