### PR TITLE
chore: add link to OCK Playground

### DIFF
--- a/apps/web/src/components/Builders/Shared/LiveDemo/index.tsx
+++ b/apps/web/src/components/Builders/Shared/LiveDemo/index.tsx
@@ -284,6 +284,18 @@ function DesktopDemo({
             >
               Docs
             </Link>
+            <Link
+              href="https://onchainkit.xyz/playground"
+              target="_blank"
+              className={classNames(
+                'rounded-lg border px-3 py-1 transition-colors',
+                mode === 'dark'
+                  ? 'border-dark-palette-line/20 hover:bg-white/10'
+                  : 'border-dark-palette-line/20 text-dark-palette-backgroundAlternate hover:bg-white/10',
+              )}
+            >
+              Playground
+            </Link>
             <button
               type="button"
               onClick={handleCopy}


### PR DESCRIPTION
**What changed? Why?**
Added a button that opens OCK playground in a new tab
<img width="1497" alt="Screenshot 2025-03-05 at 11 28 56 AM" src="https://github.com/user-attachments/assets/b005db97-5b79-42d2-ac8b-24adf1920da1" />

**How has it been tested?**
Locally