### PR TITLE
add flashblocks link and fix hero alignment

### DIFF
--- a/apps/web/src/components/Builders/Landing/Hero/index.tsx
+++ b/apps/web/src/components/Builders/Landing/Hero/index.tsx
@@ -44,13 +44,27 @@ export function Hero() {
         >
           <GridHero hasBlue />
         </div>
+        
+        <div className="absolute top-20 z-20 flex w-full px-8 md:justify-center">
+          <ButtonWithLinkAndEventLogging
+            variant={ButtonVariants.SecondaryOutline}
+            iconName="arrowRight"
+            buttonClassNames="!rounded-full text-xs md:text-sm font-medium tracking-wide bg-white/20 text-white backdrop-blur-sm border-none !px-2.5 !py-1"
+            href="https://flashblocks.base.org/"
+            eventName="flashblocks-announcement"
+            target="_blank"
+          >
+            Introducing Flashblocks: 200 milliseconds block times
+          </ButtonWithLinkAndEventLogging>
+        </div>
+
         <div className="z-10 px-6">
-          <Title className=" font-display text-[1.25rem] leading-[1.2em] tracking-tight md:text-[2rem] lg:text-[3rem]">
+          <Title className="font-display text-[1.25rem] leading-[1.2em] tracking-tight md:text-[2rem] lg:text-[3rem]">
             What do you want to build today?
           </Title>
 
-          <div className="mt-7 flex w-full flex-col items-center gap-4 md:w-[645px]">
-            <div className="z-10 flex w-full flex-col items-start justify-center gap-4 md:flex md:flex-row md:items-center">
+          <div className="mt-7 flex w-full flex-col items-center gap-4 md:w-full">
+            <div className="z-10 flex w-full flex-col items-start justify-center gap-4 md:flex md:flex-row md:items-center md:justify-center">
               <ButtonWithLinkAndEventLogging
                 variant={ButtonVariants.SecondaryOutline}
                 iconName="baseOrgDiagonalUpArrow"


### PR DESCRIPTION
**What changed? Why?**
- added a pill to highlight Flashbocks: it'll be the visual real estate we start using for our new announcements
- fixed the alignment of the hero text and button on desktop; they weren't center-aligned before
**Before**
<img width="1503" alt="Screenshot 2025-03-05 at 12 19 11 PM" src="https://github.com/user-attachments/assets/8777fbdc-2134-4fbf-bbf6-a9a41746b235" />
**After**
<img width="1504" alt="Screenshot 2025-03-05 at 12 19 41 PM" src="https://github.com/user-attachments/assets/55b6bd32-0a4d-465f-b9cb-0c66b9986c7e" />

**Notes to reviewers**
No access to vercel so please run it locally 

**How has it been tested?**
Locally on mobile and desktop