### PR TITLE
Update paymaster documentation and fix address typo

### DIFF
--- a/apps/base-docs/docs/pages/builderkits/onchainkit/paymaster/erc20-paymaster.mdx
+++ b/apps/base-docs/docs/pages/builderkits/onchainkit/paymaster/erc20-paymaster.mdx
@@ -32,7 +32,7 @@ This allows you to configure customizations such as
 - Fully sponsor UserOperations up to $1 per week - any additional UserOperations will require users to pay using ERC20 token
 - Never fully sponsor any UserOperations - all UserOperations will require users to pay using an ERC20 token
 
-**If you only want the third option (always require users to pay using erc20 token) we recommend setting your `Per User Adress Max` to `.01`.**
+**If you only want the third option (always require users to pay using erc20 token) we recommend setting your `Per User Address Max` to `.01`.**
 
 We also recommend creating a separate project to test your ERC20 custom flows so it doesn’t affect any existing regular sponsorship flows that you have.
 

--- a/apps/base-docs/docs/pages/builderkits/onchainkit/paymaster/quickstart-guide.mdx
+++ b/apps/base-docs/docs/pages/builderkits/onchainkit/paymaster/quickstart-guide.mdx
@@ -10,7 +10,7 @@ This Paymaster quickstart tutorial explains how to set up a basic app and sponso
 
 > **How to Get a Paymaster & Bundler endpoint on Base testnet (Sepolia) from CDP**
 
-1. [Create](https://coinbase.com/developer-platform) a new CDP account or [sign in](https://portal.cdp.coinbase.com) to your exsiting account.
+1. [Create](https://coinbase.com/developer-platform) a new CDP account or [sign in](https://portal.cdp.coinbase.com) to your existing account.
 2. Navigate to [Paymaster](https://portal.cdp.coinbase.com/products/bundler-and-paymaster).
 3. Add the following address to the allowlist under **Configuration**&mdash;this is the address of the contract we are calling:
 


### PR DESCRIPTION
This PR includes the following changes:

Corrected `Adress` → `Address`
Corrected `exsiting` → `existing`

These changes enhance documentation accuracy and readability.
