### PR TITLE
fix: make `isPremiumActive` a boolean

### DIFF
--- a/apps/web/src/components/Basenames/RegistrationForm/index.tsx
+++ b/apps/web/src/components/Basenames/RegistrationForm/index.tsx
@@ -164,7 +164,7 @@ export default function RegistrationForm() {
 
   const { seconds, timestamp: premiumEndTimestamp } = usePremiumEndDurationRemaining();
 
-  const isPremiumActive = premiumPrice && premiumPrice !== 0n && seconds !== 0n;
+  const isPremiumActive = Boolean(premiumPrice && premiumPrice !== 0n && seconds !== 0n);
   const mainRegistrationElementClasses = classNames(
     'z-10 flex flex-col items-start justify-between gap-6 bg-[#F7F7F7] p-8 text-gray-60 shadow-xl md:flex-row md:items-center relative z-20',
     {


### PR DESCRIPTION
**What changed? Why?**
* wrap the isPremiumActive declaration in a Boolean
* this ensures that the claim form doesn't have an extraneous "0" string literal

Before
![image](https://github.com/user-attachments/assets/1aeda737-e518-45d6-a130-cad91993cd87)

After
![image](https://github.com/user-attachments/assets/dc4bdf0c-c76c-4a67-8679-efa50f07ace6)

**Notes to reviewers**

**How has it been tested?**
locally
