### PR TITLE
Fix Typographical Errors in Documentation

### DIFF
--- a/apps/base-docs/docs/pages/cookbook/use-case-guides/commerce/build-an-ecommerce-app.mdx
+++ b/apps/base-docs/docs/pages/cookbook/use-case-guides/commerce/build-an-ecommerce-app.mdx
@@ -1,15 +1,15 @@
 ---
-title: 'Build a eCommerce App using Coinbase Commerce and OnchainKit'
+title: 'Build an eCommerce App using Coinbase Commerce and OnchainKit'
 slug: /coinbase-commerce-payment-integration
 description: Learn how to integrate Coinbase Commerce payments into your application using OnchainKit.
 authors:
   - hughescoin
 ---
 
-# Build a eCommerce App using Coinbase Commerce and OnchainKit
+# Build an eCommerce App using Coinbase Commerce and OnchainKit
 
 Looking to sell items and receive crypto on Base? Well, look no further!
-This tutorial will guide you through the process of integrating Coinbase Commerce products into your application using OnchainKit. By the end of the tutorial you will be able to spin up a demo store that allows you to sell products for crypto. If you customers do not have crypto wallets, they can easily sign up with a few clicks using [Passkeys].
+This tutorial will guide you through the process of integrating Coinbase Commerce products into your application using OnchainKit. By the end of the tutorial you will be able to spin up a demo store that allows you to sell products for crypto. If your customers do not have crypto wallets, they can easily sign up with a few clicks using [Passkeys].
 
 ## Prerequisites
 


### PR DESCRIPTION


Old Header: `# Build a eCommerce
New Header: `# Build an eCommerce
Reason: "an" is grammatically correct before "eCommerce" for better readability.