### PR TITLE
Fix typos in paymaster documentation

### DIFF
--- a/apps/base-docs/docs/pages/builderkits/onchainkit/paymaster/security.mdx
+++ b/apps/base-docs/docs/pages/builderkits/onchainkit/paymaster/security.mdx
@@ -6,7 +6,7 @@ slug: security
 
 It is important to understand where you are using your Paymaster endpoint as anyone who has your key can send requests to sponsor transactions.
 
-We strongly reccomend setting up a contract allowlist on your paymaster configuration which will lock down your paymaster to only sponsor transactions on your wallet.
+We strongly recommend setting up a contract allowlist on your paymaster configuration which will lock down your paymaster to only sponsor transactions on your wallet.
 
 Further security measures such as setting up a paymaster Proxy so that your api key is not leaked is also recommended.
 

--- a/apps/base-docs/docs/pages/builderkits/onchainkit/paymaster/troubleshooting.mdx
+++ b/apps/base-docs/docs/pages/builderkits/onchainkit/paymaster/troubleshooting.mdx
@@ -8,7 +8,7 @@ This tutorial explains how to debug common issues you may face when sending User
 
 ## Execution reverted
 
-The UserOperation was able to make it onchain, but an error occured in one of the smart contracts it interacted with, and thus the entire operation had to be reverted. This can be due to
+The UserOperation was able to make it onchain, but an error occurred in one of the smart contracts it interacted with, and thus the entire operation had to be reverted. This can be due to
 
 - Not enough gas to pay for execution
   - Try increasing the `preVerificationGas` or `callGasLimit` padding


### PR DESCRIPTION
This PR fixes two typos in the paymaster documentation:
- Corrects `reccomend` to `recommend` in `security.mdx`
- Corrects `occured` to `occurred` in `troubleshooting.mdx`

These changes improve the documentation readability and accuracy.