### PR TITLE
docs: fix typo in "Swap Settings" section

### DIFF
--- a/apps/base-docs/docs/pages/use-cases/defi-your-app.mdx
+++ b/apps/base-docs/docs/pages/use-cases/defi-your-app.mdx
@@ -101,7 +101,7 @@ The Swap component uses **Uniswap V3** as the default router, but you can also u
 
 
 ### Swap Settings
-The Swap component comes preconfigured but is highly cusotomizable. Just a couple of the settings you can customize:
+The Swap component comes preconfigured but is highly customizable. Just a couple of the settings you can customize:
 - Swap settings
 - bidirectional or unidiectional swaps
 - Gasless swaps with paymasters


### PR DESCRIPTION
**What changed? Why?**

I’ve corrected a typo in the "Swap Settings" section where "cusotomizable" was used instead of the correct spelling, "customizable."

**Notes to reviewers**

**How has it been tested?**
