### PR TITLE
docs: Fix typo in "Send via text" section

### DIFF
--- a/apps/base-docs/docs/pages/chain/wallet.md
+++ b/apps/base-docs/docs/pages/chain/wallet.md
@@ -126,7 +126,7 @@ Recipients will be prompted to make a Coinbase Wallet to claim the crypto. Wheth
 
 ![][image4]
 
-**Step 5:** Copy the link and sShare it on any platform. 
+**Step 5:** Copy the link and Share it on any platform. 
 
 * Clicking the link will prompt the recipient to open Coinbase Wallet or download Coinbase Wallet to claim the crypto   
 * If the crypto isn’t claimed within 14 weeks, it will be returned to your wallet. 


### PR DESCRIPTION
**What changed? Why?**

<img width="418" alt="Снимок экрана 2025-03-06 в 17 21 10" src="https://github.com/user-attachments/assets/b864318c-97f3-4705-b564-2cba1c9f0313" />

I corrected a small typo in the "Send via text" section. The word "sShare" was replaced with the correct spelling "**Share**" in the sentence: "Copy the link and Share it on any platform."

**Notes to reviewers**

**How has it been tested?**
