### PR TITLE
docs: Fix typo in tutorial text

### DIFF
--- a/apps/base-docs/docs/pages/cookbook/IPFS/deploy-with-fleek.mdx
+++ b/apps/base-docs/docs/pages/cookbook/IPFS/deploy-with-fleek.mdx
@@ -110,7 +110,7 @@ Then, **in the root of your project** run:
 fleek login
 ```
 
-Click the link in your terminal, then click `Confirm` in the web page that opens up. Once your are connected, click the `Visit Dashboard` button. The site automatically creates a project called `First Project`. If you'd like, you can rename it, or add a new one.
+Click the link in your terminal, then click `Confirm` in the web page that opens up. Once you are connected, click the `Visit Dashboard` button. The site automatically creates a project called `First Project`. If you'd like, you can rename it, or add a new one.
 
 Each project can include more than one site.
 


### PR DESCRIPTION
**What changed? Why?**  
I spotted a typo in the tutorial: "Once your are connected, click the `Visit Dashboard` button." The word "your" was corrected to "you" for proper grammar. The sentence now reads: "Once **you** are connected, click the `Visit Dashboard` button."

**Notes to reviewers**  
Thanks

**How has it been tested?**  
The change was reviewed manually by reading through the tutorial text. There is no need for additional testing since it’s a minor text correction.
