### PR TITLE
Fix Typographical Error 

### DIFF
--- a/apps/base-docs/docs/pages/identity/smart-wallet/guides/erc20-paymasters.mdx
+++ b/apps/base-docs/docs/pages/identity/smart-wallet/guides/erc20-paymasters.mdx
@@ -15,7 +15,7 @@ Otherwise if using a different paymaster provider, it must conform to the specif
 
 ### App setup for custom token
 
-Once you have a paymaster that is compatible with ERC20 gas payments on Smart Wallet, you are only responsible for including the approvals to the the paymaster for your token. It is recommended to periodically top up the allowance once they hit some threshold.
+Once you have a paymaster that is compatible with ERC20 gas payments on Smart Wallet, you are only responsible for including the approvals to the paymaster for your token. It is recommended to periodically top up the allowance once they hit some threshold.
 
 ```js
 


### PR DESCRIPTION
The original sentence contained a redundant "the," which was a typographical error. Removing the duplicate word improves the clarity and readability of the documentation.