### PR TITLE
docs: fix 404 links in docs

### DIFF
--- a/apps/base-docs/docs/pages/cookbook/account-abstraction/account-abstraction-on-base-using-biconomy.mdx
+++ b/apps/base-docs/docs/pages/cookbook/account-abstraction/account-abstraction-on-base-using-biconomy.mdx
@@ -42,7 +42,7 @@ To complete this tutorial, you will need to fund a wallet with ETH on Base Goerl
 
 The ETH is required for covering gas fees associated with deploying smart contracts to the network.
 
-- To fund your wallet with ETH on Base Goerli, visit a faucet listed on the [Base Faucets](https://docs.base.org/tools/network-faucets) page.
+- To fund your wallet with ETH on Base Goerli, visit a faucet listed on the [Base Faucets](https://docs.base.org/chain/network-faucets) page.
 
 ## What is Biconomy?
 

--- a/apps/base-docs/docs/pages/cookbook/smart-contract-development/foundry/deploy-with-foundry.mdx
+++ b/apps/base-docs/docs/pages/cookbook/smart-contract-development/foundry/deploy-with-foundry.mdx
@@ -55,7 +55,7 @@ In order to deploy a smart contract, you will first need a web3 wallet. You can 
 
 Deploying contracts to the blockchain requires a gas fee. Therefore, you will need to fund your wallet with ETH to cover those gas fees.
 
-For this tutorial, you will be deploying a contract to the Base Sepolia test network. You can fund your wallet with Base Sepolia ETH using one of the faucets listed on the Base [Network Faucets](https://docs.base.org/tools/network-faucets) page.
+For this tutorial, you will be deploying a contract to the Base Sepolia test network. You can fund your wallet with Base Sepolia ETH using one of the faucets listed on the Base [Network Faucets](https://docs.base.org/chain/network-faucets) page.
 
 ## Creating a project
 

--- a/apps/base-docs/docs/pages/learn/deployment-to-testnet/contract-verification-sbs.md
+++ b/apps/base-docs/docs/pages/learn/deployment-to-testnet/contract-verification-sbs.md
@@ -69,8 +69,7 @@ With your contracts verified, you can interact with them using online tools and 
 
 [`sepolia.basescan.org`]: https://sepolia.basescan.org/
 [coinbase]: https://www.coinbase.com/wallet
-[faucet]: https://docs.base.org/tools/network-faucets
-[set up]: 
+[faucet]: https://docs.base.org/chain/network-faucets 
 [coinbase settings]: https://docs.cloud.coinbase.com/wallet-sdk/docs/developer-settings
 [BaseScan]: https://sepolia.basescan.org/
 [faucets on the web]: https://coinbase.com/faucets

--- a/apps/base-docs/docs/pages/learn/hardhat-tools-and-testing/overview.md
+++ b/apps/base-docs/docs/pages/learn/hardhat-tools-and-testing/overview.md
@@ -69,6 +69,6 @@ These guides assume that you're reasonably comfortable writing basic smart contr
 
 We also assume that you've got Hardhat up and running, and can write unit tests for your smart contracts. If you're not there yet, but already know Solidity, you can [setup Hardhat here].
 
-[setup Hardhat here]: https://docs.base.org/base-learn/docs/hardhat-setup-overview/hardhat-setup-overview-sbs
+[setup Hardhat here]: https://docs.base.org/learn/hardhat-setup-overview/hardhat-setup-overview-sbs
 [Hardhat plugins]: https://hardhat.org/hardhat-runner/plugins
 [Base Learn]: https://base.org/learn


### PR DESCRIPTION
Hello! I noticed a few broken links in the documentation and decided to fix them. Also deleted [line73](https://github.com/base/web/compare/master...dsarfed:web:fix-link-docs?diff=unified&w=#diff-a36e55de458d20ef218e36646c47e2800e92ab069969e93816c0bdaefd4c4f2cL73) in `contract-verification-sbs`
![image](https://github.com/user-attachments/assets/d19bc8d1-0e8e-4603-835f-06d52cc03533)
https://docs.base.org/learn/deployment-to-testnet/contract-verification-sbs