### PR TITLE
Fix joker race website link

### DIFF
--- a/apps/web/src/data/ecosystem.json
+++ b/apps/web/src/data/ecosystem.json
@@ -1329,7 +1329,7 @@
   },
   {
     "name": "JokeRace",
-    "url": "https://www.jokerace.xyz",
+    "url": "https://jokerace.io/",
     "description": "JokeRace is the contest platform for communities to make, execute, and reward decisions. Contests enable communities to submit responses to a prompt and voters to vote on their favorites — and for anyone to win rewards if they win.",
     "imageUrl": "/images/partners/jokerace.webp",
     "category": "consumer",


### PR DESCRIPTION
Updated joker race web link

**What changed? Why?** 
The previous link on base ecosystem page is invalid and does not go to the intended page [https://www.jokerace.xyz/](url)

**Notes to reviewers**
This is what the previous link shows
![IMG_2961](https://github.com/user-attachments/assets/f5d10050-ff3e-48b4-8da3-e53f1319f7fe)


**How has it been tested?**
The new link has been tested and it’s their updated link on all their social media pages
