### PR TITLE
chore: Update URL to latest version

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -91,7 +91,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
           content="lqwNRCxYlFLIcX9EiKAvE4k4ZT8JGpdWgehEIPA7y1Y"
         />
         <script
-          src={`https://www.googletagmanager.com/gtag/js?id=${GOOGLE_ANALYTICS_ID}`}
+          src={`https://tagmanager.google.com/gtag/js?id=${GOOGLE_ANALYTICS_ID}`}
           async
           defer
         />


### PR DESCRIPTION
-Updated the Google Tag Manager URL from https://www.googletagmanager.com/gtag/js to https://tagmanager.google.com/gtag/js to reflect the latest recommended endpoint.

**What changed? Why?**
As of March 4, 2025, Google Tag Manager has introduced an enhancement where the Google tag now utilizes service workers, when available, to send data to server-side Tag Manager. This update aims to improve measurement performance and reliability

**Notes to reviewers**

**How has it been tested?**
