### PR TITLE
fix: Update get started link in Stories component

### DIFF
--- a/apps/web/src/components/Builders/Stories/BottomCta/index.tsx
+++ b/apps/web/src/components/Builders/Stories/BottomCta/index.tsx
@@ -15,7 +15,7 @@ export function BottomCta() {
             linkClassNames="text-base font-medium text-white block"
             buttonClassNames="flex items-center justify-between px-4 py-3 group"
             target="_blank"
-            href="/builders/stories" // TODO: Add link
+            href="https://docs.base.org/building-with-base/getting-started"
             eventName="bottom-cta-get-started"
           >
             <div className="flex w-40 items-center justify-between">


### PR DESCRIPTION
- Updated the href in BottomCta component to point to proper documentation page
- Replaced /builders/stories with https://docs.base.org/building-with-base/getting-started
- Fixed TODO comment by implementing proper link destination
