### PR TITLE
Correction Explanation

### DIFF
--- a/apps/base-docs/docs/pages/builderkits/onchainkit/fund/get-onramp-buy-url.mdx
+++ b/apps/base-docs/docs/pages/builderkits/onchainkit/fund/get-onramp-buy-url.mdx
@@ -38,4 +38,4 @@ const onrampBuyUrl = getOnrampBuyUrl({
 
 ## Parameters
 
-[`GetOnrampUrlWithProjectIdParams`](/builderkits/onchainkit/fund/types#getonrampurlwithsessiontokenparams) | [`GetOnrampUrlWithSessionTokenParams`](/builderkits/onchainkit/fund/types#getonrampurlwithsessiontokenparams)
+[`GetOnrampUrlWithProjectIdParams`](/builderkits/onchainkit/fund/types#getonrampurlwithprojectidparams) | [`GetOnrampUrlWithSessionTokenParams`](/builderkits/onchainkit/fund/types#getonrampurlwithsessiontokenparams)


### PR DESCRIPTION
We replaced the incorrect anchor `getonrampurlwithsessiontokenparams` with the correct anchor `getonrampurlwithprojectidparams` so the link points to the correct type section.
