### PR TITLE
Fix Incorrect Faucet Links in Documentation

### DIFF
--- a/apps/base-docs/docs/pages/cookbook/smart-contract-development/hardhat/deploy-with-hardhat.md
+++ b/apps/base-docs/docs/pages/cookbook/smart-contract-development/hardhat/deploy-with-hardhat.md
@@ -43,7 +43,7 @@ In order to deploy a smart contract, you will first need a web3 wallet. You can 
 
 Deploying contracts to the blockchain requires a gas fee. Therefore, you will need to fund your wallet with ETH to cover those gas fees.
 
-For this tutorial, you will be deploying a contract to the Base Sepolia test network. You can fund your wallet with Base Sepolia ETH using one of the faucets listed on the Base [Network Faucets](https://docs.base.org/tools/network-faucets) page.
+For this tutorial, you will be deploying a contract to the Base Sepolia test network. You can fund your wallet with Base Sepolia ETH using one of the faucets listed on the Base [Network Faucets](https://docs.base.org/chain/network-faucets) page.
 
 
 

--- a/apps/base-docs/docs/pages/learn/deployment-to-testnet/contract-verification-sbs.md
+++ b/apps/base-docs/docs/pages/learn/deployment-to-testnet/contract-verification-sbs.md
@@ -69,7 +69,7 @@ With your contracts verified, you can interact with them using online tools and 
 
 [`sepolia.basescan.org`]: https://sepolia.basescan.org/
 [coinbase]: https://www.coinbase.com/wallet
-[faucet]: https://docs.base.org/tools/network-faucets
+[faucet]: https://docs.base.org/chain/network-faucets
 [set up]: 
 [coinbase settings]: https://docs.cloud.coinbase.com/wallet-sdk/docs/developer-settings
 [BaseScan]: https://sepolia.basescan.org/

--- a/apps/base-docs/docs/pages/learn/deployment-to-testnet/deployment-to-base-sepolia-sbs.md
+++ b/apps/base-docs/docs/pages/learn/deployment-to-testnet/deployment-to-base-sepolia-sbs.md
@@ -101,7 +101,7 @@ You now have the power to put smart contracts on the blockchain! You've only dep
 [`sepolia.basescan.org`]: https://sepolia.basescan.org/
 [coinbase]: https://www.coinbase.com/wallet
 [metamask]: https://metamask.io/
-[faucet]: https://docs.base.org/tools/network-faucets
+[faucet]: https://docs.base.org/chain/network-faucets
 [set up]: 
 [coinbase settings]: https://docs.cloud.coinbase.com/wallet-sdk/docs/developer-settings
 [Metamask Settings]: https://support.metamask.io/hc/en-us/articles/13946422437147-How-to-view-testnets-in-MetaMask


### PR DESCRIPTION
This pull request updates incorrect links to the Base network faucets in multiple documentation files. The old links pointed to https://docs.base.org/tools/network-faucets, which has been replaced with the correct link https://docs.base.org/chain/network-faucets.
