### PR TITLE
Fix Broken Links to Base Learn Docs 

### DIFF
--- a/apps/base-docs/docs/pages/cookbook/smart-contract-development/foundry/verify-contract-with-basescan.md
+++ b/apps/base-docs/docs/pages/cookbook/smart-contract-development/foundry/verify-contract-with-basescan.md
@@ -288,5 +288,5 @@ Congratulations! You’ve successfully deployed and verified a smart contract us
 [login to Basescan]: https://basescan.org/login/
 [Node product]: https://portal.cdp.coinbase.com/products/node/
 [deploy smart contracts]: https://docs.base.org/tutorials/deploy-with-foundry/
-[Base Learn]: https://docs.base.org/base-learn/docs/welcome/
+[Base Learn]: https://docs.base.org/learn/welcome/
 [Foundry]: https://book.getfoundry.sh/getting-started/installation

--- a/apps/web/src/components/Bootcamp/WhatsIncluded.tsx
+++ b/apps/web/src/components/Bootcamp/WhatsIncluded.tsx
@@ -13,7 +13,7 @@ export async function WhatsIncluded() {
             <p className="font-bold">Base Learn Curriculum</p>
             <p>
               Participants will work through the{' '}
-              <a href="https://docs.base.org/base-learn/docs/welcome/">Base Learn</a> content, which
+              <a href="https://docs.base.org/learn/welcome/">Base Learn</a> content, which
               is publicly available. However, as part of the Base Bootcamp program, they will also
               have access to supplemental resources and graded projects, reviewed by Coinbase
               engineers.


### PR DESCRIPTION
1️⃣ File: docs/cookbook/smart-contract-development/foundry/verify-contract-with-basescan.md

Old: https://docs.base.org/base-learn/docs/welcome/
New: https://docs.base.org/learn/welcome/
2️⃣ File: apps/web/src/components/Bootcamp/WhatsIncluded.tsx

Old: https://docs.base.org/base-learn/docs/welcome/
New: https://docs.base.org/learn/welcome/
