### PR TITLE
chore: Use `toLowerCase()` for Predictability

### DIFF
--- a/libs/base-ui/contexts/Analytics.tsx
+++ b/libs/base-ui/contexts/Analytics.tsx
@@ -35,7 +35,7 @@ export default function AnalyticsProvider({ children, context }: AnalyticsProvid
   const fullContext = [previousContext, context].filter((c) => !!c).join('_');
   const logEventWithContext = useCallback(
     (eventName: string, action: ActionType, eventData?: CCAEventData) => {
-      const sanitizedEventName = eventName.toLocaleLowerCase();
+      const sanitizedEventName = eventName.toLowerCase();
       if (typeof window === 'undefined') return;
 
       if (isDevelopment) {


### PR DESCRIPTION
**What changed? Why?**  
Replaced `toLocaleLowerCase()` with `toLowerCase()` for event names. Since locale doesn’t matter in most cases, `toLowerCase()` ensures more predictable behavior across environments.  

**Notes to reviewers**  
This isn’t a critical issue, but I believe it makes the code more robust.

**How has it been tested?**  
Checked existing test cases and manually verified that behavior remains consistent. No regressions observed.