### PR TITLE
fix: added `isReady` to `useMemo` dependencies for proper caching

### DIFF
--- a/libs/base-ui/contexts/Experiments.tsx
+++ b/libs/base-ui/contexts/Experiments.tsx
@@ -102,7 +102,7 @@ const useExperiments = () => {
 
 const useExperiment = (flagKey: string): UseExperimentReturnValue => {
   const { isReady, getUserVariant } = useExperiments();
-  const userVariant = useMemo(() => getUserVariant(flagKey), [getUserVariant, flagKey]);
+  const userVariant = useMemo(() => getUserVariant(flagKey), [getUserVariant, flagKey, isReady]);
 
   return { isReady, userVariant };
 };


### PR DESCRIPTION
**What changed? Why?**  
Added `isReady` to the `useMemo` dependency array because it was used inside `getUserVariant` but missing from the dependencies. Without this fix, `userVariant` could be cached incorrectly.  

**Notes to reviewers**  
This ensures that `userVariant` updates correctly when `isReady` changes.

**This is a potential bug that could lead to incorrect caching of the `userVariant` value.**

**How has it been tested?**  
Tested locally by changing `isReady` and verifying that `userVariant` updates as expected.