### PR TITLE
chore: Update children prop type for better flexibility

### DIFF
--- a/libs/base-ui/Button/index.tsx
+++ b/libs/base-ui/Button/index.tsx
@@ -8,6 +8,7 @@ const variants = {
 export type ButtonProps = {
   onClick?: () => void;
   disabled?: boolean;
+  className?: string;
   children: React.ReactNode;
   children: string;
   variant?: 'primary' | 'secondary';

--- a/libs/base-ui/Button/index.tsx
+++ b/libs/base-ui/Button/index.tsx
@@ -8,7 +8,7 @@ const variants = {
 export type ButtonProps = {
   onClick?: () => void;
   disabled?: boolean;
-  className?: string;
+  children: React.ReactNode;
   children: string;
   variant?: 'primary' | 'secondary';
 };


### PR DESCRIPTION
**What changed? Why?**

updated the type of the `children` prop to `React.ReactNode` instead of `string`

**Notes to reviewers**

this change allows the component to accept not only text but also other elements, like components or React nodes, improving flexibility and usage


**How has it been tested?**
