### PR TITLE
Fix Outdated Links in Documentation 

### DIFF
--- a/apps/base-docs/docs/pages/learn/hardhat-tools-and-testing/overview.md
+++ b/apps/base-docs/docs/pages/learn/hardhat-tools-and-testing/overview.md
@@ -69,6 +69,6 @@ These guides assume that you're reasonably comfortable writing basic smart contr
 
 We also assume that you've got Hardhat up and running, and can write unit tests for your smart contracts. If you're not there yet, but already know Solidity, you can [setup Hardhat here].
 
-[setup Hardhat here]: https://docs.base.org/base-learn/docs/hardhat-setup-overview/hardhat-setup-overview-sbs
+[setup Hardhat here]: https://docs.base.org/learn/hardhat-setup-overview/hardhat-setup-overview-sbs
 [Hardhat plugins]: https://hardhat.org/hardhat-runner/plugins
 [Base Learn]: https://base.org/learn

--- a/apps/base-docs/docs/pages/learn/reading-and-displaying-data/useReadContract.md
+++ b/apps/base-docs/docs/pages/learn/reading-and-displaying-data/useReadContract.md
@@ -455,7 +455,7 @@ contract FEWeightedVoting is ERC20 {
 [Wallet Connectors]: ../frontend-setup/wallet-connectors/
 [`useAccount`]: https://wagmi.sh/react/hooks/useAccount
 [hydration error]: https://nextjs.org/docs/messages/react-hydration-error
-[ERC 20 Tokens Exercise]: https://docs.base.org/base-learn/docs/erc-20-token/erc-20-exercise
+[ERC 20 Tokens Exercise]: https://docs.base.org/learn/erc-20-token/erc-20-exercise
 [Sepolia BaseScan]: https://sepolia.basescan.org/
 [`useAccount` hook]: ./useAccount
 [Hardhat]: https://hardhat.org/

--- a/apps/base-docs/docs/pages/learn/structs/structs-exercise.md
+++ b/apps/base-docs/docs/pages/learn/structs/structs-exercise.md
@@ -80,6 +80,6 @@ import CafeUnitTest from '../../../src/components/CafeUnitTest/index.jsx'
   <summary>
     ⚠️ Spoiler Alert: Open only if tests fail</summary>
 
-Ensure your variable sizes align with their intended use, and consider the nuances of packing in Solidity. Resources: [Solidity - Layout in Storage](https://docs.soliditylang.org/en/v0.8.17/internals/layout_in_storage.html#layout-of-state-variables-in-storage), [Variables in Struct](https://docs.base.org/base-learn/docs/structs/structs-sbs#setting-up-the-struct)
+Ensure your variable sizes align with their intended use, and consider the nuances of packing in Solidity. Resources: [Solidity - Layout in Storage](https://docs.soliditylang.org/en/v0.8.17/internals/layout_in_storage.html#layout-of-state-variables-in-storage), [Variables in Struct](https://docs.base.org/learn/structs/structs-sbs#setting-up-the-struct)
 
 </details>


### PR DESCRIPTION
This PR updates outdated URLs in multiple documentation files to align with the new Base documentation structure. The previous links pointing to docs.base.org/base-learn/docs/ have been updated to docs.base.org/learn/ to ensure accuracy and consistency.