### PR TITLE
Rename useProvenWithdrawal for Consistency

### DIFF
--- a/apps/bridge/src/utils/hooks/useProvenWithdrawal.ts
+++ b/apps/bridge/src/utils/hooks/useProvenWithdrawal.ts
@@ -4,7 +4,7 @@ import { useContractRead } from 'wagmi';
 
 const { publicRuntimeConfig } = getConfig();
 
-export function useProvenWithdrawl(withdrawalHash: string | null) {
+export function useProvenWithdrawal(withdrawalHash: string | null) {
   const { data: provenWithdrawal } = useContractRead({
     address: withdrawalHash ? publicRuntimeConfig.l1OptimismPortalProxyAddress : undefined,
     abi: optimismPortalABI,

--- a/apps/bridge/src/utils/hooks/useWithdrawalStatus.ts
+++ b/apps/bridge/src/utils/hooks/useWithdrawalStatus.ts
@@ -3,7 +3,7 @@ import { useHasWithdrawalBeenFinalized } from 'apps/bridge/src/utils/hooks/useHa
 import { useHasWithdrawalBeenProven } from 'apps/bridge/src/utils/hooks/useHasWithdrawalBeenProven';
 import { useIsFinalizationPeriodElapsed } from 'apps/bridge/src/utils/hooks/useIsFinalizationPeriodElapsed';
 import { useL2OutputProposal } from 'apps/bridge/src/utils/hooks/useL2OutputProposal';
-import { useProvenWithdrawl } from 'apps/bridge/src/utils/hooks/useProvenWithdrawl';
+import { useProvenWithdrawal } from 'apps/bridge/src/utils/hooks/useProvenWithdrawal';
 import { getWithdrawalMessage } from 'apps/bridge/src/utils/transactions/getWithdrawalMessage';
 import type { WithdrawalPhase } from 'apps/bridge/src/utils/transactions/phase';
 import getConfig from 'next/config';
@@ -32,7 +32,7 @@ export function useWithdrawalStatus({
   });
   const withdrawalHasBeenProven = useHasWithdrawalBeenProven(withdrawalHash);
   const withdrawalHasBeenFinalized = useHasWithdrawalBeenFinalized(withdrawalHash);
-  const provenWithdrawal = useProvenWithdrawl(withdrawalHash);
+  const provenWithdrawal = useProvenWithdrawal(withdrawalHash);
   const { hasElapsed: finalizationPeriodHasElapsedForProvenWithdrawal, challengeWindowEndTime } =
     useIsFinalizationPeriodElapsed(provenWithdrawal?.[1]);
   const l2OutputProposal = useL2OutputProposal(provenWithdrawal?.[2]);


### PR DESCRIPTION
This PR renames the useProvenWithdrawal hook and updates all references to align with naming conventions.

📌 Changes Made
1️⃣ File: bridge/src/utils/hooks/useProvenWithdrawal.ts
🔄 Renamed Function:

Old: useProvenWithdrwal (incorrect spelling)
New: useProvenWithdrawal (corrected spelling)

2️⃣ File: apps/bridge/src/utils/hooks/useWithdrawalStatus.ts
🔄 Updated Imports & Function Calls:

Old Import:
import { useProvenWithdrwal } from 'apps/bridge/src/utils/hooks/useProvenWithdrwal';
New Import:
import { useProvenWithdrawal } from 'apps/bridge/src/utils/hooks/useProvenWithdrawal';

Function Call Fix:
Old: const withdrawalData = useProvenWithdrwal(withdrawalHash);
New: const withdrawalData = useProvenWithdrawal(withdrawalHash);
