### PR TITLE
fix: fix permissions typo

### DIFF
--- a/apps/base-docs/docs/pages/identity/smart-wallet/guides/spend-permissions/overview.mdx
+++ b/apps/base-docs/docs/pages/identity/smart-wallet/guides/spend-permissions/overview.mdx
@@ -30,7 +30,7 @@ struct SpendPermission {
 ```
 
 Spend Permissions are managed by a single manager contract, the `SpendPermissionManager`, which tracks the approval/revocation
-statuses of all perissions and enforces accurate spending limits and accounting.
+statuses of all permissions and enforces accurate spending limits and accounting.
 
 ## Approving
 


### PR DESCRIPTION
**What changed? Why?**

- Fixed "perissions" typo in spend-permissions overview

**Notes to reviewers**

**How has it been tested?**
