### PR TITLE
Add revokeAsSpender function to SpendPermissionManager interface

### DIFF
--- a/apps/base-docs/docs/pages/identity/smart-wallet/guides/spend-permissions/api-reference/spendpermissionmanager.mdx
+++ b/apps/base-docs/docs/pages/identity/smart-wallet/guides/spend-permissions/api-reference/spendpermissionmanager.mdx
@@ -73,10 +73,20 @@ function spend(SpendPermission memory spendPermission, uint160 value) external;
 
 #### `revoke`
 
-Revoke a spend permission, permanently disabling its use. Only callable by the `account` owner specified in the spend permission.
+Revoke a spend permission, permanently disabling its use. Only callable by the `account` specified in the spend permission.
 
 ```solidity
 function revoke(SpendPermission calldata spendPermission) external;
+```
+
+---
+
+#### `revokeAsSpender`
+
+Revoke a spend permission, permanently disabling its use. Only callable by the `spender` specified in the spend permission.
+
+```solidity
+function revokeAsSpender(SpendPermission calldata spendPermission) external;
 ```
 
 ---


### PR DESCRIPTION
**What changed? Why?**

Added `revokeAsSpender` function to documented interface of Smart Wallet's Spend Permissions.

**Notes to reviewers**

**How has it been tested?**
