### PR TITLE
Update Bedrock Documentation Link

### DIFF
--- a/apps/base-docs/docs/pages/chain/differences-between-ethereum-and-base.mdx
+++ b/apps/base-docs/docs/pages/chain/differences-between-ethereum-and-base.mdx
@@ -6,7 +6,7 @@ description: Documentation covering the differences between Ethereum and Base. T
 
 # Differences between Ethereum and Base
 
-Base is built on the [Bedrock](https://stack.optimism.io/docs/releases/bedrock/explainer/) release of the [OP Stack](https://stack.optimism.io/), which is designed from the ground up to be as close to Ethereum as possible. Because of this, there are very few differences when it comes to building on Base and Ethereum.
+Base is built on the [Bedrock](https://docs.optimism.io/stack/rollup/overview) release of the [OP Stack](https://stack.optimism.io/), which is designed from the ground up to be as close to Ethereum as possible. Because of this, there are very few differences when it comes to building on Base and Ethereum.
 
 However, there are still some minor discrepancies between the behavior of Base and Ethereum that you should be aware of when building apps on top of Base.
 


### PR DESCRIPTION
This update fixes an outdated link to the Bedrock documentation in the differences-between-ethereum-and-base.mdx file.
The old link (https://stack.optimism.io/docs/releases/bedrock/explainer/) has been replaced with the correct one (https://docs.optimism.io/stack/rollup/overview).
