### PR TITLE
flag that Sub Accounts are only available in keys development currently

### DIFF
--- a/apps/base-docs/docs/pages/identity/smart-wallet/features/sub-accounts.mdx
+++ b/apps/base-docs/docs/pages/identity/smart-wallet/features/sub-accounts.mdx
@@ -13,3 +13,10 @@ Sub Accounts are hierarchical, app-specific accounts that extend from a user's p
 - When an app requests a Sub Account creation and the user approves, all future signing and transaction requests will use the Sub Account.
 
 Refer to the [Sub Account Reference](/identity/smart-wallet/sdk/sub-account-reference) for more details on how to create and manage Sub Accounts.
+
+:::tip[Development]
+Note: Sub Accounts are currently only available in the Coinbase Smart Wallet development environment.
+In the CoinbaseWalletSDK properties you can set the `keysUrl` to `https://keys-dev.coinbase.com/connect` to use this environment.
+
+If you would like to use Sub Accounts with Coinbase Smart Wallet in our production environment, please [reach out](https://discord.com/invite/buildonbase) to the Base team.
+:::

--- a/apps/base-docs/docs/pages/identity/smart-wallet/guides/sub-accounts/setup.mdx
+++ b/apps/base-docs/docs/pages/identity/smart-wallet/guides/sub-accounts/setup.mdx
@@ -46,7 +46,12 @@ Install viem for blockchain interactions
 npm install viem
 ```
 
-**Note:** Make sure you're using version 4.4.0 or above of the Coinbase Wallet SDK.
+:::tip[Development Environment]
+Note: Sub Accounts are currently only available in the Coinbase Smart Wallet development environment.
+In the CoinbaseWalletSDK properties you can set the `keysUrl` to `https://keys-dev.coinbase.com/connect` to use this environment.
+:::
+
+**Note:** Sub Accounts are only supported in version 4.4.0 or above of the Coinbase Wallet SDK.
 
 ## Project Structure
 


### PR DESCRIPTION
**What changed? Why?**

Adding a note to the docs that Sub Accounts is only available in the Coinbase Smart Wallet development environment for now.

**Notes to reviewers**

**How has it been tested?**
