### PR TITLE
 chore: Add OnchainKit docs for getNames, useNames, getAvatars, and useAvatars.

### DIFF
--- a/apps/base-docs/docs/contexts/CookieBannerWrapper.tsx
+++ b/apps/base-docs/docs/contexts/CookieBannerWrapper.tsx
@@ -3,8 +3,9 @@ import ClientAnalyticsScript from '@/components/ClientAnalyticsScript/ClientAnal
 import { isDevelopment } from '@/constants.ts';
 
 // CJS import
-import pkg from '@coinbase/cookie-banner';
-const { CookieBanner } = pkg;
+// import pkg from '@coinbase/cookie-banner';
+// const { CookieBanner } = pkg;
+import { CookieBanner } from '@coinbase/cookie-banner';
 
 export const cookieBannerTheme = {
   colors: {

--- a/apps/base-docs/docs/contexts/CookieBannerWrapper.tsx
+++ b/apps/base-docs/docs/contexts/CookieBannerWrapper.tsx
@@ -3,9 +3,8 @@ import ClientAnalyticsScript from '@/components/ClientAnalyticsScript/ClientAnal
 import { isDevelopment } from '@/constants.ts';
 
 // CJS import
-// import pkg from '@coinbase/cookie-banner';
-// const { CookieBanner } = pkg;
-import { CookieBanner } from '@coinbase/cookie-banner';
+import pkg from '@coinbase/cookie-banner';
+const { CookieBanner } = pkg;
 
 export const cookieBannerTheme = {
   colors: {

--- a/apps/base-docs/docs/pages/builderkits/onchainkit/identity/get-avatars.mdx
+++ b/apps/base-docs/docs/pages/builderkits/onchainkit/identity/get-avatars.mdx
@@ -1,0 +1,81 @@
+# `getAvatars`
+
+The `getAvatars` utility is designed to retrieve multiple avatars from an onchain identity
+provider for an array of ENS names or Basenames in a single batch request.
+
+Consider the utility instead of the hook when you
+use it with Next.js or any Node.js backend.
+
+## Usage
+
+Get avatars for multiple ENS names:
+
+:::code-group
+
+```tsx twoslash [code]
+import { getAvatars } from '@coinbase/onchainkit/identity';
+
+const ensNames = ['vitalik.eth', 'zizzamia.eth'];
+const avatars = await getAvatars({ ensNames });
+```
+
+```ts [return value]
+[
+  'https://ipfs.io/ipfs/QmSP4nq9fnN9dAiCj42ug9Wa79rqmQerZXZch82VqpiH7U/image.gif',
+  'https://ipfs.io/ipfs/QmQ9RT2SrZ6TWUjrQxG4bNnhb3nDqBE5Ld1j9GYvk3kTjf'
+]
+```
+
+:::
+
+Get avatars for multiple Basenames:
+
+:::code-group
+
+```tsx twoslash [code]
+import { getAvatars } from '@coinbase/onchainkit/identity';
+import { base } from 'viem/chains';
+
+const ensNames = ['zizzamia.base.eth', 'coinbase.base.eth'];
+const avatars = await getAvatars({ ensNames, chain: base });
+```
+
+```ts [return value]
+[
+  'https://ipfs.io/ipfs/QmQ9RT2SrZ6TWUjrQxG4bNnhb3nDqBE5Ld1j9GYvk3kTjf',
+  'https://ipfs.io/ipfs/QmXHFnSXcN7CSuVcyF3vyPgPcPvLQyLpKYBaNpx3x3bPAZ'
+]
+```
+
+:::
+
+Get avatars for a mix of ENS names and Basenames:
+
+:::code-group
+
+```tsx twoslash [code]
+import { getAvatars } from '@coinbase/onchainkit/identity';
+import { base } from 'viem/chains';
+
+const ensNames = ['vitalik.eth', 'zizzamia.base.eth'];
+const avatars = await getAvatars({ ensNames, chain: base });
+```
+
+```ts [return value]
+[
+  'https://ipfs.io/ipfs/QmSP4nq9fnN9dAiCj42ug9Wa79rqmQerZXZch82VqpiH7U/image.gif',
+  'https://ipfs.io/ipfs/QmQ9RT2SrZ6TWUjrQxG4bNnhb3nDqBE5Ld1j9GYvk3kTjf'
+]
+```
+
+:::
+
+## Returns
+
+Array of [`GetAvatarReturnType`](/builderkits/onchainkit/identity/types#getavatarreturntype)
+
+## Parameters
+
+### GetAvatars
+
+[`GetAvatars`](/builderkits/onchainkit/identity/types#getavatars) 

--- a/apps/base-docs/docs/pages/builderkits/onchainkit/identity/get-names.mdx
+++ b/apps/base-docs/docs/pages/builderkits/onchainkit/identity/get-names.mdx
@@ -16,14 +16,14 @@ Get ENS names from multiple addresses:
 import { getNames } from '@coinbase/onchainkit/identity';
 
 const addresses = [
-  '0x02feeb0AdE57b6adEEdE5A4EEea6Cf8c21BeB6B1',
+  '0x4bEf0221d6F7Dd0C969fe46a4e9b339a84F52FDF',
   '0x838aD0EAE54F99F1926dA7C3b6bFbF617389B4D9'
 ];
 const names = await getNames({ addresses });
 ```
 
 ```ts [return value]
-['zizzamia.eth', 'vitalik.eth']
+['paulcramer.eth', 'vitalik.eth']
 ```
 
 :::
@@ -37,14 +37,14 @@ import { getNames } from '@coinbase/onchainkit/identity';
 import { base } from 'viem/chains';
 
 const addresses = [
-  '0x02feeb0AdE57b6adEEdE5A4EEea6Cf8c21BeB6B1',
+  '0x4bEf0221d6F7Dd0C969fe46a4e9b339a84F52FDF',
   '0x4bEf0221d6F7Dd0C969fe46a4e9b339a84F52FDF'
 ];
 const names = await getNames({ addresses, chain: base });
 ```
 
 ```ts [return value]
-['zizzamia.base.eth', 'coinbase.base.eth']
+['paul.base.eth', 'coinbase.base.eth']
 ```
 
 :::
@@ -57,14 +57,14 @@ Get a mix of ENS names and sliced addresses when some addresses don't have names
 import { getNames } from '@coinbase/onchainkit/identity';
 
 const addresses = [
-  '0x02feeb0AdE57b6adEEdE5A4EEea6Cf8c21BeB6B1',
+  '0x4bEf0221d6F7Dd0C969fe46a4e9b339a84F52FDF',
   '0x1234567890abcdef1234567890abcdef12345678'
 ];
 const names = await getNames({ addresses });
 ```
 
 ```ts [return value]
-['zizzamia.eth', null]
+['paulcramer.eth', null]
 ```
 
 :::

--- a/apps/base-docs/docs/pages/builderkits/onchainkit/identity/get-names.mdx
+++ b/apps/base-docs/docs/pages/builderkits/onchainkit/identity/get-names.mdx
@@ -1,0 +1,80 @@
+# `getNames`
+
+The `getNames` utility is designed to retrieve multiple names from an onchain identity
+provider for an array of addresses in a single batch request.
+
+Consider the utility instead of the hook when you
+use it with Next.js or any Node.js backend.
+
+## Usage
+
+Get ENS names from multiple addresses:
+
+:::code-group
+
+```tsx twoslash [code]
+import { getNames } from '@coinbase/onchainkit/identity';
+
+const addresses = [
+  '0x02feeb0AdE57b6adEEdE5A4EEea6Cf8c21BeB6B1',
+  '0x838aD0EAE54F99F1926dA7C3b6bFbF617389B4D9'
+];
+const names = await getNames({ addresses });
+```
+
+```ts [return value]
+['zizzamia.eth', 'vitalik.eth']
+```
+
+:::
+
+Get Basenames from multiple addresses:
+
+:::code-group
+
+```tsx twoslash [code]
+import { getNames } from '@coinbase/onchainkit/identity';
+import { base } from 'viem/chains';
+
+const addresses = [
+  '0x02feeb0AdE57b6adEEdE5A4EEea6Cf8c21BeB6B1',
+  '0x4bEf0221d6F7Dd0C969fe46a4e9b339a84F52FDF'
+];
+const names = await getNames({ addresses, chain: base });
+```
+
+```ts [return value]
+['zizzamia.base.eth', 'coinbase.base.eth']
+```
+
+:::
+
+Get a mix of ENS names and sliced addresses when some addresses don't have names:
+
+:::code-group
+
+```tsx twoslash [code]
+import { getNames } from '@coinbase/onchainkit/identity';
+
+const addresses = [
+  '0x02feeb0AdE57b6adEEdE5A4EEea6Cf8c21BeB6B1',
+  '0x1234567890abcdef1234567890abcdef12345678'
+];
+const names = await getNames({ addresses });
+```
+
+```ts [return value]
+['zizzamia.eth', null]
+```
+
+:::
+
+## Returns
+
+Array of [`GetNameReturnType`](/builderkits/onchainkit/identity/types#getnamereturntype)
+
+## Parameters
+
+### GetNames
+
+[`GetNames`](/builderkits/onchainkit/identity/types#getnames) 

--- a/apps/base-docs/docs/pages/builderkits/onchainkit/identity/types.mdx
+++ b/apps/base-docs/docs/pages/builderkits/onchainkit/identity/types.mdx
@@ -100,8 +100,8 @@ type EthBalanceReact = {
 
 ```ts
 type GetAddress = {
-  name: string | Basename;
-  chain?: Chain;
+  name: string | Basename; // Name to resolve
+  chain?: Chain; // Optional chain for domain resolution
 };
 ```
 
@@ -126,8 +126,8 @@ type GetAttestationsOptions = {
 
 ```ts
 type GetAvatar = {
-  chain?: Chain; // Optional chain for domain resolution
   ensName: string; // The ENS name to fetch the avatar for.
+  chain?: Chain; // Optional chain for domain resolution
 };
 ```
 
@@ -150,6 +150,15 @@ type GetName = {
 
 ```ts
 type GetNameReturnType = string | null;
+```
+
+## `GetNames`
+
+```ts
+type GetNames = {
+  addresses: Address[]; // Array of Ethereum addresses to resolve names for
+  chain?: Chain; // Optional chain for domain resolution
+};
 ```
 
 ## `IdentityContextType`
@@ -203,12 +212,12 @@ type UseAvatarOptions = {
 };
 ```
 
-## `UseQueryOptions`
+## `UseAvatarsOptions`
 
 ```ts
-type UseQueryOptions = {
-  enabled?: boolean;
-  cacheTime?: number;
+type UseAvatarsOptions = {
+  ensNames: string[]; // Array of ENS names to resolve avatars for
+  chain?: Chain; // Optional chain for domain resolution
 };
 ```
 
@@ -216,8 +225,16 @@ type UseQueryOptions = {
 
 ```ts
 type UseNameOptions = {
-  address: Address; // The Ethereum address for which the ENS name is to be fetched.
+  address: Address; // The address for which the ENS or Basename is to be fetched.
   chain?: Chain; // Optional chain for domain resolution
 };
 ```
 
+## `UseNamesOptions`
+
+```ts
+type UseNamesOptions = {
+  addresses: Address[]; // Array of addresses to resolve ENS or Basenames for
+  chain?: Chain; // Optional chain for domain resolution
+};
+```

--- a/apps/base-docs/docs/pages/builderkits/onchainkit/identity/use-avatars.mdx
+++ b/apps/base-docs/docs/pages/builderkits/onchainkit/identity/use-avatars.mdx
@@ -1,0 +1,67 @@
+# `useAvatars`
+
+The `useAvatars` hook is used to get multiple avatar image URLs from an onchain identity
+provider for an array of ENS names or Basenames in a single batch request.
+
+## Usage
+
+Get avatars for multiple ENS names:
+
+:::code-group
+
+```tsx twoslash [code]
+import { useAvatars } from '@coinbase/onchainkit/identity';
+
+const ensNames = ['vitalik.eth', 'zizzamia.eth'];
+const { data: avatars, isLoading } = useAvatars({ ensNames });
+```
+
+```ts [return value]
+{ 
+  data: [
+    'https://ipfs.io/ipfs/QmSP4nq9fnN9dAiCj42ug9Wa79rqmQerZXZch82VqpiH7U/image.gif',
+    'https://ipfs.io/ipfs/QmQ9RT2SrZ6TWUjrQxG4bNnhb3nDqBE5Ld1j9GYvk3kTjf'
+  ], 
+  isLoading: false 
+}
+```
+
+:::
+
+Get avatars for multiple Basenames:
+
+:::code-group
+
+```tsx twoslash [code]
+import { useAvatars } from '@coinbase/onchainkit/identity';
+import { base } from 'viem/chains';
+
+const ensNames = ['zizzamia.base.eth', 'coinbase.base.eth'];
+const { data: avatars, isLoading } = useAvatars({ ensNames, chain: base });
+```
+
+```ts [return value]
+{ 
+  data: [
+    'https://ipfs.io/ipfs/QmQ9RT2SrZ6TWUjrQxG4bNnhb3nDqBE5Ld1j9GYvk3kTjf',
+    'https://ipfs.io/ipfs/QmXHFnSXcN7CSuVcyF3vyPgPcPvLQyLpKYBaNpx3x3bPAZ'
+  ], 
+  isLoading: false 
+}
+```
+
+:::
+
+## Returns
+
+[`useQuery<Promise<GetAvatarReturnType[]>>`](/builderkits/onchainkit/identity/types#getavatarreturntype)
+
+## Parameters
+
+### UseAvatarsOptions
+
+[`UseAvatarsOptions`](/builderkits/onchainkit/identity/types#useavatarsoptions)
+
+### UseQueryOptions
+
+[`UseQueryOptions`](/builderkits/onchainkit/identity/types#usequeryoptions) 

--- a/apps/base-docs/docs/pages/builderkits/onchainkit/identity/use-avatars.mdx
+++ b/apps/base-docs/docs/pages/builderkits/onchainkit/identity/use-avatars.mdx
@@ -12,7 +12,7 @@ Get avatars for multiple ENS names:
 ```tsx twoslash [code]
 import { useAvatars } from '@coinbase/onchainkit/identity';
 
-const ensNames = ['vitalik.eth', 'zizzamia.eth'];
+const ensNames = ['vitalik.eth', 'paulcramer.eth'];
 const { data: avatars, isLoading } = useAvatars({ ensNames });
 ```
 
@@ -36,7 +36,7 @@ Get avatars for multiple Basenames:
 import { useAvatars } from '@coinbase/onchainkit/identity';
 import { base } from 'viem/chains';
 
-const ensNames = ['zizzamia.base.eth', 'coinbase.base.eth'];
+const ensNames = ['paul.base.eth', 'coinbase.base.eth'];
 const { data: avatars, isLoading } = useAvatars({ ensNames, chain: base });
 ```
 

--- a/apps/base-docs/docs/pages/builderkits/onchainkit/identity/use-names.mdx
+++ b/apps/base-docs/docs/pages/builderkits/onchainkit/identity/use-names.mdx
@@ -1,0 +1,67 @@
+# `useNames`
+
+The `useNames` hook is used to get multiple names from an onchain identity provider
+for an array of addresses in a single batch request.
+
+## Usage
+
+Get ENS names from multiple addresses:
+
+:::code-group
+
+```tsx twoslash [code]
+import { useNames } from '@coinbase/onchainkit/identity';
+
+const addresses = [
+  '0x02feeb0AdE57b6adEEdE5A4EEea6Cf8c21BeB6B1',
+  '0x838aD0EAE54F99F1926dA7C3b6bFbF617389B4D9'
+];
+const { data: names, isLoading } = useNames({ addresses });
+```
+
+```ts [return value]
+{ 
+  data: ['zizzamia.eth', 'vitalik.eth'], 
+  isLoading: false 
+}
+```
+
+:::
+
+Get Basenames from multiple addresses:
+
+:::code-group
+
+```tsx twoslash [code]
+import { useNames } from '@coinbase/onchainkit/identity';
+import { base } from 'viem/chains';
+
+const addresses = [
+  '0x02feeb0AdE57b6adEEdE5A4EEea6Cf8c21BeB6B1',
+  '0x4bEf0221d6F7Dd0C969fe46a4e9b339a84F52FDF'
+];
+const { data: names, isLoading } = useNames({ addresses, chain: base });
+```
+
+```ts [return value]
+{ 
+  data: ['zizzamia.base.eth', 'coinbase.base.eth'], 
+  isLoading: false 
+}
+```
+
+:::
+
+## Returns
+
+[`useQuery<Promise<GetNameReturnType[]>>`](/builderkits/onchainkit/identity/types#getnamereturntype)
+
+## Parameters
+
+### UseNamesOptions
+
+[`UseNamesOptions`](/builderkits/onchainkit/identity/types#usenamesoptions)
+
+### UseQueryOptions
+
+[`UseQueryOptions`](/builderkits/onchainkit/identity/types#usequeryoptions) 

--- a/apps/base-docs/docs/pages/builderkits/onchainkit/identity/use-names.mdx
+++ b/apps/base-docs/docs/pages/builderkits/onchainkit/identity/use-names.mdx
@@ -13,7 +13,7 @@ Get ENS names from multiple addresses:
 import { useNames } from '@coinbase/onchainkit/identity';
 
 const addresses = [
-  '0x02feeb0AdE57b6adEEdE5A4EEea6Cf8c21BeB6B1',
+  '0x4bEf0221d6F7Dd0C969fe46a4e9b339a84F52FDF',
   '0x838aD0EAE54F99F1926dA7C3b6bFbF617389B4D9'
 ];
 const { data: names, isLoading } = useNames({ addresses });
@@ -21,7 +21,7 @@ const { data: names, isLoading } = useNames({ addresses });
 
 ```ts [return value]
 { 
-  data: ['zizzamia.eth', 'vitalik.eth'], 
+  data: ['paulcramer.eth', 'vitalik.eth'], 
   isLoading: false 
 }
 ```
@@ -37,7 +37,7 @@ import { useNames } from '@coinbase/onchainkit/identity';
 import { base } from 'viem/chains';
 
 const addresses = [
-  '0x02feeb0AdE57b6adEEdE5A4EEea6Cf8c21BeB6B1',
+  '0x4bEf0221d6F7Dd0C969fe46a4e9b339a84F52FDF',
   '0x4bEf0221d6F7Dd0C969fe46a4e9b339a84F52FDF'
 ];
 const { data: names, isLoading } = useNames({ addresses, chain: base });
@@ -45,7 +45,7 @@ const { data: names, isLoading } = useNames({ addresses, chain: base });
 
 ```ts [return value]
 { 
-  data: ['zizzamia.base.eth', 'coinbase.base.eth'], 
+  data: ['paul.base.eth', 'coinbase.base.eth'], 
   isLoading: false 
 }
 ```

--- a/apps/base-docs/sidebar.ts
+++ b/apps/base-docs/sidebar.ts
@@ -418,8 +418,16 @@ export const sidebar: Sidebar = [
                     link: '/builderkits/onchainkit/identity/get-avatar',
                   },
                   {
+                    text: 'getAvatars',
+                    link: '/builderkits/onchainkit/identity/get-avatars',
+                  },
+                  {
                     text: 'getName',
                     link: '/builderkits/onchainkit/identity/get-name',
+                  },
+                  {
+                    text: 'getNames',
+                    link: '/builderkits/onchainkit/identity/get-names',
                   },
                   {
                     text: 'useAddress',
@@ -430,8 +438,16 @@ export const sidebar: Sidebar = [
                     link: '/builderkits/onchainkit/identity/use-avatar',
                   },
                   {
+                    text: 'useAvatars',
+                    link: '/builderkits/onchainkit/identity/use-avatars',
+                  },
+                  {
                     text: 'useName',
                     link: '/builderkits/onchainkit/identity/use-name',
+                  },
+                  {
+                    text: 'useNames',
+                    link: '/builderkits/onchainkit/identity/use-names',
                   },
                 ],
               },


### PR DESCRIPTION
**What changed? Why?**
Add OnchainKit docs for `getNames`, `useNames`, `getAvatars`, `useAvatars`. 
**Notes to reviewers**

**How has it been tested?**
<img width="845" alt="Screenshot 2025-03-11 at 1 58 12 PM" src="https://github.com/user-attachments/assets/91697714-f839-4348-a3e6-45d7c7e04f4a" />

<img width="865" alt="Screenshot 2025-03-11 at 1 58 22 PM" src="https://github.com/user-attachments/assets/7b25d279-3217-49ef-87e6-842173dd8e5a" />

<img width="858" alt="Screenshot 2025-03-11 at 1 58 33 PM" src="https://github.com/user-attachments/assets/d4c2a725-33e5-461a-966d-12aa6bef11f3" />

<img width="959" alt="Screenshot 2025-03-11 at 1 58 44 PM" src="https://github.com/user-attachments/assets/63544169-43f8-403c-8877-ea7bebacd839" />
