### PR TITLE
Improving Smart Wallet landing page -> docs funnel

### DIFF
--- a/apps/base-docs/docs/pages/identity/smart-wallet/introduction/getting-started.mdx
+++ b/apps/base-docs/docs/pages/identity/smart-wallet/introduction/getting-started.mdx
@@ -1,0 +1,87 @@
+---
+title: "Getting Started"
+description: "Learn how to integrate Smart Wallet into your app"
+sidebar_position: 1
+---
+
+import StartBuilding from '@/components/StartBuilding';
+import InstallationOptions from '@/components/InstallationOptions';
+
+# Getting Started
+
+## What is Smart Wallet?
+
+Smart Wallet is the fastest way for users to connect to your app, onramp in seconds, and experience world-class onchain UX:
+
+- **Universal account:** An account that just works anywhere your users go.
+- **Instant onboarding:** Bring users onchain in seconds with secure passkey sign-in. No app or extension required.
+- **Onchain made simple:** Build delightful user experiences with sponsored transactions, spend permissions, and batch operations.
+- **Built-in onramps:** Simple account funding for users — with Apple Pay, debit card, or Coinbase Exchange balances.
+- **Free to use:** Smart Wallet is 100% free for users and developers. No fees whatsoever.
+
+## Quick Start with OnchainKit
+
+We recommend starting a new OnchainKit app using `create onchain`, which sets up everything automatically for you. To create a project, run:
+
+```bash [Terminal]
+npm create onchain@latest
+```
+
+After the prompts, `create onchain` will create a folder with your project name and install the required dependencies.
+
+You can also checkout our pre-built templates:
+
+- [Onchain Commerce](https://onchain-commerce-template.vercel.app/)
+- [NFT minting](https://ock-mint.vercel.app/)
+- [Funding flow](https://github.com/fakepixels/fund-component)
+- [Social profile](https://github.com/fakepixels/ock-identity)
+
+## Add to your existing project
+
+###Install for Web
+
+:::code-group
+
+```bash [npm]
+npm i @coinbase/wallet-sdk
+```
+
+```bash [pnpm]
+pnpm i @coinbase/wallet-sdk
+```
+
+```bash [yarn]
+yarn add @coinbase/wallet-sdk
+```
+
+```bash [bun]
+bun i @coinbase/wallet-sdk
+```
+
+:::
+
+### Install for React Native
+
+:::code-group
+
+```bash [npm]
+npm i @mobile-wallet-protocol/client
+```
+
+```bash [pnpm]
+pnpm i @mobile-wallet-protocol/client
+```
+
+```bash [yarn]
+yarn add @mobile-wallet-protocol/client
+```
+
+```bash [bun]
+bun i @mobile-wallet-protocol/client
+```
+
+:::
+
+<InstallationOptions />
+
+<StartBuilding />

--- a/apps/base-docs/docs/pages/index.mdx
+++ b/apps/base-docs/docs/pages/index.mdx
@@ -101,7 +101,7 @@ import { paymasterSvg } from '@/components/svg/paymasterSvg';
             title="Smart Wallet"
             description="A passkey-based universal account to connect with the onchain world."
             icon={smartWalletSvg}
-            href="/identity/smart-wallet/introduction/install-web"
+            href="/identity/smart-wallet/introduction/getting-started"
           />
           <BrowseCard
             title="AgentKit"

--- a/apps/base-docs/sidebar.ts
+++ b/apps/base-docs/sidebar.ts
@@ -587,6 +587,10 @@ export const sidebar: Sidebar = [
           {
             text: 'Introduction',
             items: [
+              {
+                text: 'Getting Started',
+                link: '/identity/smart-wallet/introduction/getting-started',
+              },
               { text: 'Install for Web', link: '/identity/smart-wallet/introduction/install-web' },
               {
                 text: 'Install for React Native',
@@ -603,7 +607,6 @@ export const sidebar: Sidebar = [
               },
             ],
           },
-
           {
             text: 'Features',
             items: [

--- a/apps/web/app/(base-org)/builders/smart-wallet/page.tsx
+++ b/apps/web/app/(base-org)/builders/smart-wallet/page.tsx
@@ -1,22 +1,13 @@
 import type { Metadata } from 'next';
-import { ButtonVariants } from 'apps/web/src/components/base-org/Button/types';
 import Container from 'apps/web/src/components/base-org/Container';
-import Title from 'apps/web/src/components/base-org/typography/Title';
-import Text from 'apps/web/src/components/base-org/typography/Text';
-import { TitleLevel } from 'apps/web/src/components/base-org/typography/Title/types';
-import { ButtonWithLinkAndEventLogging } from 'apps/web/src/components/Button/ButtonWithLinkAndEventLogging';
 import { InfoCards } from 'apps/web/src/components/Builders/SmartWallet/InfoCards';
 import { Transactions } from 'apps/web/src/components/Builders/SmartWallet/Transactions';
 import { Customers } from 'apps/web/src/components/Builders/SmartWallet/Customers';
-import wallet from 'apps/web/src/components/Builders/SmartWallet/svg/wallet.svg';
-import headerImage from 'apps/web/src/components/Builders/SmartWallet/header.png';
 import { CtaBanner } from 'apps/web/src/components/Builders/Shared/CtaBanner';
-import Image, { StaticImageData } from 'next/image';
-import { Icon } from 'apps/web/src/components/Icon/Icon';
 import { LiveDemo } from 'apps/web/src/components/Builders/Shared/LiveDemo';
-import { TextVariant } from 'apps/web/src/components/base-org/typography/Text/types';
-import Link from 'apps/web/src/components/Link';
+import { Hero } from 'apps/web/src/components/Builders/SmartWallet/Hero';
 import smartWalletCover from './smart-wallet.png';
+import { CopyNpmButton } from 'apps/web/src/components/Builders/Shared/CopyNpmButton';
 
 export const metadata: Metadata = {
   metadataBase: new URL('https://base.org'),
@@ -28,71 +19,19 @@ export const metadata: Metadata = {
   },
 };
 
-export default async function BaseWallet() {
+// Extract the array to a constant to avoid creating a new array on each render
+const WALLET_COMPONENTS = ['Wallet'];
+
+export default function BaseWallet() {
   return (
     <Container>
       <main className="mb-32 flex min-h-screen w-full flex-col items-center gap-40 bg-black px-2 pt-20 md:px-0">
-        {/* Header  */}
-        <div className="flex w-full items-center justify-between gap-1 pt-20 max-sm:flex-col sm:pb-20">
-          <div className="flex max-w-xl flex-col gap-2">
-            <div className="flex gap-4 pb-6 text-[#578BFA] max-md:flex-col md:items-center md:gap-5">
-              <div className="flex items-center gap-2">
-                <Image
-                  src={wallet as StaticImageData}
-                  alt="wallet"
-                  width={32}
-                  height={32}
-                  className="h-5 w-5"
-                />
-                <Title level={TitleLevel.Title3} className="font-bold">
-                  Smart Wallet
-                </Title>
-              </div>
-              <Link
-                href="https://docs.base.org/identity/smart-wallet/introduction/base-gasless-campaign"
-                target="_blank"
-                className="flex items-center justify-center gap-2 rounded-full border px-2 py-1 max-md:mr-auto"
-              >
-                <Text variant={TextVariant.Body}>$15K gas credits available</Text>
-                <Icon name="arrowRight" width={12} height={12} color="currentColor" />
-              </Link>
-            </div>
-            <Title level={TitleLevel.Display3} className="font-bold max-sm:hidden">
-              The universal account for the onchain future
-            </Title>
-            <Title level={TitleLevel.Title1} className="font-bold sm:hidden">
-              The universal account for the onchain future
-            </Title>
-            <Title level={TitleLevel.Title3} className="max-w-2xl text-gray-muted">
-              A single sign-on for the open internet. Simple, secure, powerful — no app or extension
-              required.
-            </Title>
-            <div className="flex gap-6 pt-5">
-              <ButtonWithLinkAndEventLogging
-                target="_blank"
-                variant={ButtonVariants.Secondary}
-                buttonClassNames="flex items-center justify-between px-4 pb-3 pt-3 group font-medium"
-                eventName="wallet-start-building"
-                href="https://docs.base.org/identity/smart-wallet/introduction/install-web"
-              >
-                <div className="flex items-center gap-4">
-                  <span>Start building</span>
-                  <div className="transition-transform duration-200 group-hover:translate-x-1">
-                    <Icon name="arrowRight" width={16} height={16} color="black" />
-                  </div>
-                </div>
-              </ButtonWithLinkAndEventLogging>
-            </div>
-          </div>
-
-          <Image src={headerImage} alt="header-image" width={400} className="max-sm:hidden" />
-        </div>
-
+        <Hero />
         <Customers />
         <InfoCards />
         <Transactions />
         <LiveDemo
-          components={['Wallet']}
+          components={WALLET_COMPONENTS}
           title="Unlock onboarding superpowers with a few lines of code"
           hideDescription
         />
@@ -100,35 +39,7 @@ export default async function BaseWallet() {
         <CtaBanner
           title="Integrate Smart Wallet in minutes"
           description="Start building with a starter template or see documentation."
-          cta={
-            <div className="flex w-full gap-4 max-sm:flex-col max-sm:items-center">
-              <ButtonWithLinkAndEventLogging
-                variant={ButtonVariants.Secondary}
-                iconName="fork"
-                href="https://github.com/brendan-defi/onchainkit-wallet-island-demo"
-                target="_blank"
-                eventName="wallet-fork-template"
-                iconSize={16}
-                buttonClassNames="flex items-center justify-between px-4 pb-3 pt-3 font-medium"
-              >
-                Fork a template
-              </ButtonWithLinkAndEventLogging>
-              <ButtonWithLinkAndEventLogging
-                href="https://docs.base.org/identity/smart-wallet/introduction/install-web"
-                target="_blank"
-                variant={ButtonVariants.SecondaryOutline}
-                buttonClassNames="flex items-center justify-between px-4 pb-3 pt-3 group font-medium"
-                eventName="wallet-docs"
-              >
-                <div className="flex items-center justify-between gap-6">
-                  <span>Docs</span>
-                  <div className="transition-transform duration-200 group-hover:translate-x-1">
-                    <Icon name="arrowRight" width={16} height={16} color="white" />
-                  </div>
-                </div>
-              </ButtonWithLinkAndEventLogging>
-            </div>
-          }
+          cta={<CopyNpmButton />}
         />
       </main>
     </Container>

--- a/apps/web/src/components/Builders/Shared/CopyNpmButton.tsx
+++ b/apps/web/src/components/Builders/Shared/CopyNpmButton.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { Icon } from 'apps/web/src/components/Icon/Icon';
+import { ButtonVariants } from 'apps/web/src/components/base-org/Button/types';
+import { ButtonWithLinkAndEventLogging } from 'apps/web/src/components/Button/ButtonWithLinkAndEventLogging';
+
+const SMART_WALLET_DOCS_LINK =
+  'https://docs.base.org/identity/smart-wallet/introduction/getting-started';
+
+export function CopyNpmButton() {
+  const [hasCopied, setHasCopied] = useState(false);
+
+  const handleCopy = useCallback(() => {
+    void navigator.clipboard.writeText('npm create onchain');
+    setHasCopied(true);
+    setTimeout(() => setHasCopied(false), 2000); // Reset after 2 seconds
+  }, []);
+
+  return (
+    <div className="flex w-full gap-4 max-sm:flex-col max-sm:items-center">
+      <button
+        type="button"
+        className="inline-flex items-center gap-2.5 rounded-lg bg-white px-4 pb-3 pt-3 font-medium text-dark-palette-primaryForeground transition-colors hover:bg-white/90"
+        onClick={handleCopy}
+      >
+        npm create onchain
+        {hasCopied ? (
+          <div className="text-green-60">
+            <Icon name="checkmark" width="16" height="16" color="currentColor" />
+          </div>
+        ) : (
+          <Icon name="copy" width="16" height="16" color="currentColor" />
+        )}
+      </button>
+      <ButtonWithLinkAndEventLogging
+        href={SMART_WALLET_DOCS_LINK}
+        target="_blank"
+        variant={ButtonVariants.SecondaryOutline}
+        buttonClassNames="flex items-center justify-between px-4 pb-3 pt-3 group font-medium"
+        eventName="wallet-docs"
+      >
+        <div className="flex items-center justify-between gap-6">
+          <span>Docs</span>
+          <div className="transition-transform duration-200 group-hover:translate-x-1">
+            <Icon name="arrowRight" width={16} height={16} color="white" />
+          </div>
+        </div>
+      </ButtonWithLinkAndEventLogging>
+    </div>
+  );
+}

--- a/apps/web/src/components/Builders/SmartWallet/Customers.tsx
+++ b/apps/web/src/components/Builders/SmartWallet/Customers.tsx
@@ -74,7 +74,7 @@ export function Customers() {
   return (
     <div className="flex w-full flex-col gap-10 tracking-tight">
       <Title level={TitleLevel.Title1} className="font-bold">
-        Powering the best onchain experiences
+        Powering your favorite onchain apps
       </Title>
       <div className="relative flex w-full flex-col items-center justify-center overflow-hidden">
         <Marquee className="gap-8 [--duration:20s]" pauseOnHover>

--- a/apps/web/src/components/Builders/SmartWallet/Hero.tsx
+++ b/apps/web/src/components/Builders/SmartWallet/Hero.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { ButtonVariants } from 'apps/web/src/components/base-org/Button/types';
+import Title from 'apps/web/src/components/base-org/typography/Title';
+import Text from 'apps/web/src/components/base-org/typography/Text';
+import { TitleLevel } from 'apps/web/src/components/base-org/typography/Title/types';
+import Image, { StaticImageData } from 'next/image';
+import wallet from 'apps/web/src/components/Builders/SmartWallet/svg/wallet.svg';
+import headerImage from 'apps/web/src/components/Builders/SmartWallet/header.png';
+import { ButtonWithLinkAndEventLogging } from 'apps/web/src/components/Button/ButtonWithLinkAndEventLogging';
+import { Icon } from 'apps/web/src/components/Icon/Icon';
+import Link from 'apps/web/src/components/Link';
+import { TextVariant } from 'apps/web/src/components/base-org/typography/Text/types';
+import { useCallback, useState } from 'react';
+
+const SMART_WALLET_DOCS_LINK =
+  'https://docs.base.org/identity/smart-wallet/introduction/install-web';
+
+export function Hero() {
+  const [hasCopied, setHasCopied] = useState(false);
+
+  const handleCopy = useCallback(() => {
+    void navigator.clipboard.writeText('npm create onchain');
+    setHasCopied(true);
+    setTimeout(() => setHasCopied(false), 2000); // Reset after 2 seconds
+  }, []);
+
+  return (
+    <div className="flex w-full items-center justify-between gap-1 pt-20 max-sm:flex-col sm:pb-20">
+      <div className="flex max-w-xl flex-col gap-2">
+        <div className="flex gap-4 pb-6 text-[#578BFA] max-md:flex-col md:items-center md:gap-5">
+          <div className="flex items-center gap-2">
+            <Image
+              src={wallet as StaticImageData}
+              alt="wallet"
+              width={32}
+              height={32}
+              className="h-5 w-5"
+            />
+            <Title level={TitleLevel.Title3} className="font-bold">
+              Smart Wallet
+            </Title>
+          </div>
+          <Link
+            href="https://docs.base.org/identity/smart-wallet/introduction/base-gasless-campaign"
+            target="_blank"
+            className="flex items-center justify-center gap-2 rounded-full border px-2 py-1 max-md:mr-auto"
+          >
+            <Text variant={TextVariant.Body}>$15K gas credits available</Text>
+            <Icon name="arrowRight" width={12} height={12} color="currentColor" />
+          </Link>
+        </div>
+        <Title level={TitleLevel.Display3} className="font-bold max-sm:hidden">
+          The universal account for the onchain future
+        </Title>
+        <Title level={TitleLevel.Title1} className="font-bold sm:hidden">
+          The universal account for the onchain future
+        </Title>
+        <Title level={TitleLevel.Title3} className="max-w-2xl text-gray-muted">
+          A single sign-on for the open internet. Simple, secure, powerful — no app or extension
+          required.
+        </Title>
+        <div className="flex gap-4 pt-5 max-sm:max-w-[240px] max-sm:flex-col">
+          <button
+            type="button"
+            className="inline-flex items-center gap-2.5 rounded-lg bg-white px-4 pb-3 pt-3 font-medium text-dark-palette-primaryForeground transition-colors hover:bg-white/90 max-sm:mr-auto"
+            onClick={handleCopy}
+          >
+            npm create onchain
+            {hasCopied ? (
+              <div className="text-green-60">
+                <Icon name="checkmark" width="16" height="16" color="currentColor" />
+              </div>
+            ) : (
+              <Icon name="copy" width="16" height="16" color="currentColor" />
+            )}
+          </button>
+          <ButtonWithLinkAndEventLogging
+            variant={ButtonVariants.SecondaryOutline}
+            buttonClassNames="flex items-center justify-between px-4 pb-3 pt-3 group font-medium"
+            href={SMART_WALLET_DOCS_LINK}
+            eventName="smart-wallet-documentation-click"
+            target="_blank"
+          >
+            <div className="flex items-center justify-between gap-6">
+              <span>Docs</span>
+              <div className="transition-transform duration-200 group-hover:translate-x-1">
+                <Icon name="arrowRight" width={16} height={16} color="white" />
+              </div>
+            </div>
+          </ButtonWithLinkAndEventLogging>
+        </div>
+      </div>
+
+      <Image src={headerImage} alt="header-image" width={400} className="max-sm:hidden" />
+    </div>
+  );
+}

--- a/tsconfig.projectOptions.json
+++ b/tsconfig.projectOptions.json
@@ -9,6 +9,8 @@
     "emitDeclarationOnly": true,
     "incremental": true,
     "rootDirs": ["."],
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "moduleResolution": "NodeNext",
+    "module": "NodeNext"
   }
 }


### PR DESCRIPTION
**What changed? Why?**

Took a stab at improving the landing page CTAs for smart wallet by providing a quickstart option via OnchainKit, and docs for more. Structure is more similar to OnchainKit site + docs now, which convert really well.

This is meant to be a jumping-off point rather than a recommendation - will share this with the team for feedback!

**Notes to reviewers**

**How has it been tested?**

Locally
