### PR TITLE
fix: OnchainKit Mint hooks navigation

### DIFF
--- a/apps/base-docs/sidebar.ts
+++ b/apps/base-docs/sidebar.ts
@@ -456,11 +456,11 @@ export const sidebar: Sidebar = [
                 items: [
                   {
                     text: 'useTokenDetails',
-                    link: '/builderkits/onchainkit/mint/use-token-details',
+                    link: '/builderkits/onchainkit/hooks/use-token-details',
                   },
                   {
                     text: 'useMintDetails',
-                    link: '/builderkits/onchainkit/mint/use-mint-details',
+                    link: '/builderkits/onchainkit/hooks/use-mint-details',
                   },
                 ],
               },


### PR DESCRIPTION
**What changed? Why?**
Fix Mint hooks path. 

`Page not found` error for the OnchainKit Mint hooks:

- https://docs.base.org/builderkits/onchainkit/mint/use-token-details
- https://docs.base.org/builderkits/onchainkit/mint/use-mint-details

<img width="633" alt="Screenshot 2025-03-12 at 10 38 34 AM" src="https://github.com/user-attachments/assets/f32e950f-2b8d-4cb5-a3c5-47faaeae0fcb" />

**Notes to reviewers**

**How has it been tested?**
<img width="1042" alt="Screenshot 2025-03-12 at 10 38 45 AM" src="https://github.com/user-attachments/assets/72da43f5-bca3-4b20-8c87-e69360dafabf" />
