### PR TITLE
chore: truncate ecosystem project descriptions

### DIFF
--- a/apps/web/src/components/Ecosystem/Card.tsx
+++ b/apps/web/src/components/Ecosystem/Card.tsx
@@ -12,6 +12,8 @@ type Props = {
   subcategory: string;
 };
 
+const MAX_DESCRIPTION_LENGTH = 200;
+
 function getNiceDomainDisplayFromUrl(url: string) {
   return url.replace('https://', '').replace('http://', '').replace('www.', '').split('/')[0];
 }
@@ -24,6 +26,11 @@ export default function EcosystemCard({
   category,
   subcategory,
 }: Props) {
+  const truncatedDescription =
+    description.length > MAX_DESCRIPTION_LENGTH
+      ? description.slice(0, MAX_DESCRIPTION_LENGTH) + '...'
+      : description;
+
   return (
     <Card innerClassName="p-4 group/ecosystem-card">
       <a
@@ -73,7 +80,9 @@ export default function EcosystemCard({
               {getNiceDomainDisplayFromUrl(url)}
             </span>
           </div>
-          <Text className="opacity-80 group-hover/ecosystem-card:opacity-100">{description}</Text>
+          <Text className="opacity-80 group-hover/ecosystem-card:opacity-100">
+            {truncatedDescription}
+          </Text>
         </div>
       </a>
     </Card>

--- a/apps/web/src/data/ecosystem.json
+++ b/apps/web/src/data/ecosystem.json
@@ -3840,14 +3840,6 @@
     "subcategory": "portfolio"
   },
   {
-    "name": "20lab",
-    "description": "20lab.app is a customizable ERC-20, SPL (Solana) & Sui token generator with over 17 extendable features. Test our generator for free and manage functions via token owner dashboard.",
-    "url": "https://20lab.app/generate/erc20-token/base/",
-    "imageUrl": "/images/partners/20lab.png",
-    "category": "infra",
-    "subcategory": "developer tool"
-  },
-  {
     "name": "based.gift",
     "description": "Send beautiful onchain gift cards on Base. Simple and an easy customizable way to give the gift of crypto for any occasion.",
     "url": "https://based.gift",


### PR DESCRIPTION
**What changed? Why?**
* removed duplicate entry in ecosystem json that caused filtering / display issues
* added text truncation on project descriptions to limit to 200 chars

after:
normal font size:
![image](https://github.com/user-attachments/assets/6886df32-2869-4390-a896-23a1549e5832)

very large font:
![image](https://github.com/user-attachments/assets/804fc63f-8a00-4917-b9c9-7222508b0b49)

before (note incorrect 20lab inclusion because it is a duplicate entry, causing a duplicate key react issue):
![image](https://github.com/user-attachments/assets/b67856ca-52ea-4cab-b451-818d13032a2f)

**Notes to reviewers**
* used string slicing (always showing 200 chars) instead of line clamping / height restrictions for accessibility reasons
* this approach always shows the same number of characters regardless of text size

**How has it been tested?**
locally