### PR TITLE
fix: add black background behind content body

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -107,7 +107,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
           }}
         />
       </head>
-      <body className="flex min-h-screen flex-col">
+      <body className="flex min-h-screen flex-col bg-black">
         <AppProviders>
           <DatadogInit />
           {children}


### PR DESCRIPTION
**What changed? Why?**
* added black background to layout so that scrolling doesn't result in white background peeking out

after:
<img width="1241" alt="image" src="https://github.com/user-attachments/assets/828361fb-5cc6-4aab-94f8-2243635ad6ff" />


before:
<img width="1239" alt="image" src="https://github.com/user-attachments/assets/9962c8e5-4f20-4117-844d-a0ff0ce04bf4" />

**Notes to reviewers**

**How has it been tested?**
