### PR TITLE
fix: prevent overscroll to avoid "peaking" background colors

### DIFF
--- a/apps/web/app/global.css
+++ b/apps/web/app/global.css
@@ -31,6 +31,7 @@
 }
 
 body {
+  overscroll-behavior: none;
   overflow-x: hidden;
   height: 100%;
   margin: 0;

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -107,7 +107,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
           }}
         />
       </head>
-      <body className="flex min-h-screen flex-col bg-black">
+      <body className="flex min-h-screen flex-col">
         <AppProviders>
           <DatadogInit />
           {children}


### PR DESCRIPTION
**What changed? Why?**
* removed bg color from global layout
* added `overscroll-behavior: none` to global css to prevent the "peaking" background color

**Notes to reviewers**

**How has it been tested?**
locally, vercel preview
- [x] base.org
- [x] base.org/ecosystem
- [x] base.org/names
- [x] base.org/name/brendan