### PR TITLE
fix: update dispute game addresses

### DIFF
--- a/apps/base-docs/docs/pages/chain/base-contracts.mdx
+++ b/apps/base-docs/docs/pages/chain/base-contracts.mdx
@@ -94,7 +94,7 @@ Certain contracts are mandatory according to the [OP Stack SDK](https://stack.op
 | DelayedWETHProxy (FDG)       | [0x489c2E5ebe0037bDb2DC039C5770757b8E54eA1F](https://sepolia.etherscan.io/address/0x489c2E5ebe0037bDb2DC039C5770757b8E54eA1F) |
 | DelayedWETHProxy (PDG)       | [0x27A6128F707de3d99F89Bf09c35a4e0753E1B808](https://sepolia.etherscan.io/address/0x27A6128F707de3d99F89Bf09c35a4e0753E1B808) |
 | DisputeGameFactoryProxy      | [0xd6E6dBf4F7EA0ac412fD8b65ED297e64BB7a06E1](https://sepolia.etherscan.io/address/0xd6E6dBf4F7EA0ac412fD8b65ED297e64BB7a06E1) |
-| FaultDisputeGame             | [0x605b4248500c0a144e39bbb04c05c539e388e222](https://sepolia.etherscan.io/address/0x605b4248500c0a144e39bbb04c05c539e388e222) |
+| FaultDisputeGame             | [0x9cd8b02e84df3ef61db3b34123206568490cb279](https://sepolia.etherscan.io/address/0x9cd8b02e84df3ef61db3b34123206568490cb279) |
 | L1CrossDomainMessenger       | [0xC34855F4De64F1840e5686e64278da901e261f20](https://sepolia.etherscan.io/address/0xC34855F4De64F1840e5686e64278da901e261f20) |
 | L1ERC721Bridge               | [0x21eFD066e581FA55Ef105170Cc04d74386a09190](https://sepolia.etherscan.io/address/0x21eFD066e581FA55Ef105170Cc04d74386a09190) |
 | L1StandardBridge             | [0xfd0Bf71F60660E2f608ed56e1659C450eB113120](https://sepolia.etherscan.io/address/0xfd0Bf71F60660E2f608ed56e1659C450eB113120) |
@@ -102,7 +102,7 @@ Certain contracts are mandatory according to the [OP Stack SDK](https://stack.op
 | MIPS                         | [0x47B0E34C1054009e696BaBAAd56165e1e994144d](https://sepolia.etherscan.io/address/0x47B0E34C1054009e696BaBAAd56165e1e994144d) |
 | OptimismMintableERC20Factory | [0xb1efB9650aD6d0CC1ed3Ac4a0B7f1D5732696D37](https://sepolia.etherscan.io/address/0xb1efB9650aD6d0CC1ed3Ac4a0B7f1D5732696D37) |
 | OptimismPortal               | [0x49f53e41452C74589E85cA1677426Ba426459e85](https://sepolia.etherscan.io/address/0x49f53e41452C74589E85cA1677426Ba426459e85) |
-| PermissionedDisputeGame      | [0x71ff927ee7b96f873c249093846aa292f374aef4](https://sepolia.etherscan.io/address/0x71ff927ee7b96f873c249093846aa292f374aef4) |
+| PermissionedDisputeGame      | [0xcca6a4916fa6de5d671cc77760a3b10b012cca16](https://sepolia.etherscan.io/address/0xcca6a4916fa6de5d671cc77760a3b10b012cca16) |
 | PreimageOracle               | [0x92240135b46fc1142dA181f550aE8f595B858854](https://sepolia.etherscan.io/address/0x92240135b46fc1142dA181f550aE8f595B858854) |
 | ProxyAdmin                   | [0x0389E59Aa0a41E4A413Ae70f0008e76CAA34b1F3](https://sepolia.etherscan.io/address/0x0389E59Aa0a41E4A413Ae70f0008e76CAA34b1F3) |
 | SystemConfig                 | [0xf272670eb55e895584501d564AfEB048bEd26194](https://sepolia.etherscan.io/address/0xf272670eb55e895584501d564AfEB048bEd26194) |


### PR DESCRIPTION
**What changed? Why?**
We re-deployed our Sepolia `FaultDisputeGame` and `PermissionedDisputeGame` contracts today to prepare for testnet Pectra upgrades.

**Notes to reviewers**
You can confirm the new FDG and PDG contract addresses [here](https://github.com/base/contract-deployments/blob/main/sepolia/2025-03-12-upgrade-fault-proofs/addresses.json).

**How has it been tested?**
