### PR TITLE
fix: add supported network info to getPortfolios doc

### DIFF
--- a/apps/base-docs/docs/pages/builderkits/onchainkit/api/get-portfolios.mdx
+++ b/apps/base-docs/docs/pages/builderkits/onchainkit/api/get-portfolios.mdx
@@ -10,6 +10,11 @@ Before using this endpoint, make sure to obtain a [Client API Key](https://porta
 from Coinbase Developer Platform.
 :::
 
+:::info
+Please note: `getPortfolios` is only available for Base mainnet and Ethereum mainnet.
+You can control the network in the `OnchainKitProvider` by setting the `chain` prop.
+:::
+
 ## Usage
 
 :::code-group


### PR DESCRIPTION
**What changed? Why?**
* added supported network info to OnchainKit's `getPortoflios` endpoint documentation

**Notes to reviewers**

**How has it been tested?**
vercel preview:
<img width="733" alt="image" src="https://github.com/user-attachments/assets/3baaf5d6-4af4-44c4-a9c5-07752dfbbafe" />

