### PR TITLE
chore: enable bridge builds

### DIFF
--- a/.codeflow.yml
+++ b/.codeflow.yml
@@ -15,6 +15,10 @@ build:
         name: docs
         path: ./apps/base-docs/Dockerfile
         architecture: amd64
+    - BaldurECR:
+        name: bridge
+        path: ./apps/bridge/Dockerfile
+        architecture: amd64
   multi_arch: true
 
 operate:

--- a/apps/bridge/Dockerfile
+++ b/apps/bridge/Dockerfile
@@ -18,7 +18,7 @@ ENV BUGSNAG_SESSIONS_URL https://sessions.coinbase.com
 # Install dependencies
 RUN yarn --immutable
 
-RUN yarn workspace @app/bridge next build
+RUN yarn workspace @app/bridge build
 RUN yarn workspaces focus --all --production
 
 EXPOSE 3000


### PR DESCRIPTION
**What changed? Why?**
* reenabled building bridge service — required in order to deploy bridge for deprecation

**Notes to reviewers**

**How has it been tested?**

Have you tested the following pages?
- [x] base.org
- [x] base.org/ecosystem
- [x] base.org/resources
- [x] base.org/build
- [x] base.org/names
- [x] base.org/name/jesse
- [x] base.org/manage-names
