### PR TITLE
chore: Update OCK Identity hooks with TanStack support

### DIFF
--- a/apps/base-docs/docs/pages/builderkits/onchainkit/identity/use-address.mdx
+++ b/apps/base-docs/docs/pages/builderkits/onchainkit/identity/use-address.mdx
@@ -2,6 +2,8 @@
 
 The `useAddress` hook is used to get an address from an onchain identity provider for a given name.
 
+It is implemented with [useQuery](https://tanstack.com/query/latest/docs/framework/react/reference/useQuery) from `@tanstack/react-query`, and returns a `UseQueryResult` object, allowing you to pass through all `@tanstack/react-query` options.
+
 ## Usage
 
 ```tsx twoslash

--- a/apps/base-docs/docs/pages/builderkits/onchainkit/identity/use-avatar.mdx
+++ b/apps/base-docs/docs/pages/builderkits/onchainkit/identity/use-avatar.mdx
@@ -3,6 +3,8 @@
 The `useAvatar` hook is used to get avatar image url from an onchain identity
 provider for a given name.
 
+It is implemented with [useQuery](https://tanstack.com/query/latest/docs/framework/react/reference/useQuery) from `@tanstack/react-query`, and returns a `UseQueryResult` object, allowing you to pass through all `@tanstack/react-query` options.
+
 ## Usage
 
 ```tsx twoslash

--- a/apps/base-docs/docs/pages/builderkits/onchainkit/identity/use-avatars.mdx
+++ b/apps/base-docs/docs/pages/builderkits/onchainkit/identity/use-avatars.mdx
@@ -3,6 +3,8 @@
 The `useAvatars` hook is used to get multiple avatar image URLs from an onchain identity
 provider for an array of ENS names or Basenames in a single batch request.
 
+It is implemented with [useQuery](https://tanstack.com/query/latest/docs/framework/react/reference/useQuery) from `@tanstack/react-query`, and returns a `UseQueryResult` object, allowing you to pass through all `@tanstack/react-query` options.
+
 ## Usage
 
 Get avatars for multiple ENS names:

--- a/apps/base-docs/docs/pages/builderkits/onchainkit/identity/use-name.mdx
+++ b/apps/base-docs/docs/pages/builderkits/onchainkit/identity/use-name.mdx
@@ -3,6 +3,8 @@
 The `useName` hook is used to get name from an onchain identity provider
 for a given address.
 
+It is implemented with [useQuery](https://tanstack.com/query/latest/docs/framework/react/reference/useQuery) from `@tanstack/react-query`, and returns a `UseQueryResult` object, allowing you to pass through all `@tanstack/react-query` options.
+
 ## Usage
 
 Get ENS name from an address:

--- a/apps/base-docs/docs/pages/builderkits/onchainkit/identity/use-names.mdx
+++ b/apps/base-docs/docs/pages/builderkits/onchainkit/identity/use-names.mdx
@@ -3,6 +3,8 @@
 The `useNames` hook is used to get multiple names from an onchain identity provider
 for an array of addresses in a single batch request.
 
+It is implemented with [useQuery](https://tanstack.com/query/latest/docs/framework/react/reference/useQuery) from `@tanstack/react-query`, and returns a `UseQueryResult` object, allowing you to pass through all `@tanstack/react-query` options.
+
 ## Usage
 
 Get ENS names from multiple addresses:


### PR DESCRIPTION
**What changed? Why?**
Update Identity docs with new TanStack support info. 

- Docs update from [feat: Enhance Identity hooks with full TanStack Query options support](https://github.com/coinbase/onchainkit/pull/2116#top)

<img width="670" alt="Screenshot 2025-03-17 at 1 26 02 PM" src="https://github.com/user-attachments/assets/8e897098-07b9-4b1b-ad99-e4a06ed20010" />

**Notes to reviewers**

**How has it been tested?**

Have you tested the following pages?
- [] base.org
- [] base.org/ecosystem
- [] base.org/resources
- [] base.org/build
- [] base.org/names
- [] base.org/name/jesse
- [] base.org/manage-names
