### PR TITLE
fix: OnchainKit Badge and Identity Card links

### DIFF
--- a/apps/base-docs/docs/pages/builderkits/onchainkit/identity/badge.mdx
+++ b/apps/base-docs/docs/pages/builderkits/onchainkit/identity/badge.mdx
@@ -4,7 +4,7 @@ import App from '@/components/App';
 
 # `<Badge />`
 
-Use `Badge` component along with [`Avatar`](avatar) or [`Name`](name) components to display user attestations attached to their account
+Use `Badge` component along with [`Avatar`](/builderkits/onchainkit/identity/avatar) or [`Name`](/builderkits/onchainkit/identity/name) components to display user attestations attached to their account
 
 ## Usage
 
@@ -49,7 +49,7 @@ import { Badge } from '@coinbase/onchainkit/identity';
 
 ## Badge on `<Name />` and `<Avatar />`
 
-Badge with [`<Name />`](name), best used when [`<Name />`](name) are displayed alongside [`<Avatar />`](avatar) components.
+Badge with [`<Name />`](/builderkits/onchainkit/identity/name), best used when [`<Name />`](/builderkits/onchainkit/identity/name) are displayed alongside [`<Avatar />`](/builderkits/onchainkit/identity/avatar) components.
 
 In both examples we use the Coinbase [Verified Account](https://base.easscan.org/schema/view/0xf8b05c79f090979bf4a80270aba232dff11a10d9ca55c4f88de95317970f0de9) schema ID to show the Coinbase verified badge on the Name and Avatar components.
 
@@ -83,7 +83,7 @@ const COINBASE_VERIFIED_ACCOUNT_SCHEMA_ID =
   </Identity>
 </App>
 
-Badge with [`<Avatar />`](avatar), best used when [`<Avatar />`](avatar) is not paired with any labels.
+Badge with [`<Avatar />`](/builderkits/onchainkit/identity/avatar), best used when [`<Avatar />`](/builderkits/onchainkit/identity/avatar) is not paired with any labels.
 
 ```tsx twoslash
 import { base } from 'viem/chains';

--- a/apps/base-docs/docs/pages/builderkits/onchainkit/identity/identity-card.mdx
+++ b/apps/base-docs/docs/pages/builderkits/onchainkit/identity/identity-card.mdx
@@ -109,7 +109,7 @@ The component handles various error states gracefully:
 
 ## Related Components
 
-- [`<Avatar>`](avatar) - Displays user avatars
-- [`<Name>`](name) - Displays resolved names
-- [`<Identity>`](identity) - Simplified identity display
+- [`<Avatar>`](/builderkits/onchainkit/identity/avatar) - Displays user avatars
+- [`<Name>`](/builderkits/onchainkit/identity/name) - Displays resolved names
+- [`<Identity>`](/builderkits/onchainkit/identity/identity) - Simplified identity display
 


### PR DESCRIPTION
**What changed? Why?**
All links in the Badge and Identity Card documentation page are broken - this PR fixes them. 

<img width="578" alt="Screenshot 2025-03-18 at 11 16 09 AM" src="https://github.com/user-attachments/assets/7bf6a231-f9b9-48d6-bcd0-50b0fc7ecddd" />

**Notes to reviewers**

**How has it been tested?**
Tested locally. 

Have you tested the following pages?
- [] base.org
- [] base.org/ecosystem
- [] base.org/resources
- [] base.org/build
- [] base.org/names
- [] base.org/name/jesse
- [] base.org/manage-names
