### PR TITLE
chore: add Custom Supplemental Providers to sidebar

### DIFF
--- a/apps/base-docs/sidebar.ts
+++ b/apps/base-docs/sidebar.ts
@@ -48,6 +48,10 @@ export const sidebar: Sidebar = [
                 text: 'OnchainKitProvider',
                 link: '/builderkits/onchainkit/config/onchainkit-provider',
               },
+              {
+                text: 'Custom Supplemental Providers',
+                link: '/builderkits/onchainkit/config/supplemental-providers',
+              },
             ],
           },
           {


### PR DESCRIPTION
**What changed? Why?**
Add orphaned page, "Custom Supplemental Providers" to the side navigation.

**Notes to reviewers**

**How has it been tested?**

Have you tested the following pages?
- [x] base.org
- [x] base.org/ecosystem
- [x] base.org/resources
- [x] base.org/build
- [x] base.org/names
- [x] base.org/name/jesse
- [x] base.org/manage-names
