### PR TITLE
chore: fix CookieBannerWrapper import in dev env

### DIFF
--- a/apps/base-docs/docs/contexts/CookieBannerWrapper.tsx
+++ b/apps/base-docs/docs/contexts/CookieBannerWrapper.tsx
@@ -2,9 +2,15 @@ import { CookieManagerProvider } from '@/components/CookieManager/CookieManagerP
 import ClientAnalyticsScript from '@/components/ClientAnalyticsScript/ClientAnalyticsScript.tsx';
 import { isDevelopment } from '@/constants.ts';
 
-// CJS import
+/**
+ * CJS import
+ * This import structure for CookieBanner is necessary because in prod, direct
+ * destructuring from @coinbase/cookie-banner fails.
+ * However in dev, the import fails because the pkg is not found.
+ * This structure allows the import to work in prod, and disables the banner in dev.
+ */
 import pkg from '@coinbase/cookie-banner';
-const { CookieBanner } = pkg;
+const { CookieBanner } = isDevelopment ? {} : pkg;
 
 export const cookieBannerTheme = {
   colors: {


### PR DESCRIPTION
**What changed? Why?**
* modified CookieBanner import to handle error thrown in dev mode

**Notes to reviewers**

**How has it been tested?**

Have you tested the following pages?
- [] base.org
- [] base.org/ecosystem
- [] base.org/resources
- [] base.org/build
- [] base.org/names
- [] base.org/name/jesse
- [] base.org/manage-names
