### PR TITLE
docs: Fix 404 on Base Token List page

### DIFF
--- a/apps/base-docs/docs/contexts/CookieBannerWrapper.tsx
+++ b/apps/base-docs/docs/contexts/CookieBannerWrapper.tsx
@@ -2,9 +2,8 @@ import { CookieManagerProvider } from '@/components/CookieManager/CookieManagerP
 import ClientAnalyticsScript from '@/components/ClientAnalyticsScript/ClientAnalyticsScript.tsx';
 import { isDevelopment } from '@/constants.ts';
 
-// CJS import
-import pkg from '@coinbase/cookie-banner';
-const { CookieBanner } = pkg;
+// Replace the CJS import with ESM import
+import { CookieBanner } from '@coinbase/cookie-banner';
 
 export const cookieBannerTheme = {
   colors: {

--- a/apps/base-docs/docs/contexts/CookieBannerWrapper.tsx
+++ b/apps/base-docs/docs/contexts/CookieBannerWrapper.tsx
@@ -2,8 +2,9 @@ import { CookieManagerProvider } from '@/components/CookieManager/CookieManagerP
 import ClientAnalyticsScript from '@/components/ClientAnalyticsScript/ClientAnalyticsScript.tsx';
 import { isDevelopment } from '@/constants.ts';
 
-// Replace the CJS import with ESM import
-import { CookieBanner } from '@coinbase/cookie-banner';
+// CJS import
+import pkg from '@coinbase/cookie-banner';
+const { CookieBanner } = pkg;
 
 export const cookieBannerTheme = {
   colors: {

--- a/apps/base-docs/docs/pages/chain/bridge-an-l1-token-to-base.mdx
+++ b/apps/base-docs/docs/pages/chain/bridge-an-l1-token-to-base.mdx
@@ -17,7 +17,9 @@ The steps below explain how to get your token on the Base Token List.
 
 ### Step 1: Deploy your token on Base
 
-Select your preferred bridging framework and use it to deploy an ERC-20 for your token on Base. We recommend you use the framework provided by Base's [standard bridge](https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/bridges.md) contracts, and furthermore deploy your token using the [OptimismMintableERC20Factory](https://docs.base.org/base-contracts/#l2-contract-addresses). Deploying your token on Base in this manner provides us with guarantees that will smooth the approval process. If you choose a different bridging framework, its interface must be compatible with that of the standard bridge, otherwise it may be difficult for us to support.
+Select your preferred bridging framework and use it to deploy an ERC-20 for your token on Base. We recommend you use the framework provided by Base's [standard bridge](https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/bridges.md) contracts, and furthermore deploy your token using the [OptimismMintableERC20Factory]. You can find the list of contracts addresses [here].
+
+Deploying your token on Base in this manner provides us with guarantees that will smooth the approval process. If you choose a different bridging framework, its interface must be compatible with that of the standard bridge, otherwise it may be difficult for us to support.
 
 ### Step 2: Submit details for your token
 
@@ -27,3 +29,7 @@ Follow the instructions in the [Github repository](https://github.com/ethereum-o
 
 Reviews are regularly conducted by the Base team and you should receive a reply within 24-72 hours (depending on if the PR is opened on a weekday, weekend or holiday).
 
+---
+
+[OptimismMintableERC20Factory]: https://docs.optimism.io/app-developers/tutorials/bridging/standard-bridge-standard-token
+[here]: ../chain/base-contracts


### PR DESCRIPTION
**What changed? Why?**
* Fix `cookie-banner` import to fix destructure error
* FIx 404 link to Optimism docs + Base contract addresses page

**Notes to reviewers**

**How has it been tested?**

Have you tested the following pages?
- [x] base.org
- [x] base.org/ecosystem
- [x] base.org/resources
- [x] base.org/build
- [x] base.org/names
- [x] base.org/name/jesse
- [x] base.org/manage-names
