### PR TITLE
docs: add sub-pages to navigation for Sub Accounts

### DIFF
--- a/apps/base-docs/sidebar.ts
+++ b/apps/base-docs/sidebar.ts
@@ -874,7 +874,28 @@ export const sidebar: Sidebar = [
               },
               { text: 'Paymasters', link: '/identity/smart-wallet/guides/paymasters' },
               { text: 'ERC20 Paymasters', link: '/identity/smart-wallet/guides/erc20-paymasters' },
-              { text: 'Sub Accounts', link: '/identity/smart-wallet/guides/sub-accounts/overview' },
+              {
+                text: 'Sub Accounts',
+                collapsed: true,
+                items: [
+                  {
+                    text: 'Overview',
+                    link: '/identity/smart-wallet/guides/sub-accounts/overview',
+                  },
+                  {
+                    text: 'Setup',
+                    link: '/identity/smart-wallet/guides/sub-accounts/setup',
+                  },
+                  {
+                    text: 'Creating Sub Accounts',
+                    link: '/identity/smart-wallet/guides/sub-accounts/creating-sub-accounts',
+                  },
+                  {
+                    text: 'Using Sub Accounts',
+                    link: '/identity/smart-wallet/guides/sub-accounts/using-sub-accounts',
+                  },
+                ],
+              },
               {
                 text: 'Spend Permissions',
                 collapsed: true,


### PR DESCRIPTION
**What changed? Why?**

It's difficult to find a few pages for Sub Accounts. This PR adds them to the sidebar

| Before | After |
|--------|--------|
| ![DS 2025-03-20 at 11 20 04@2x](https://github.com/user-attachments/assets/bb799838-29c3-423d-82ba-f84d40e342f4) | ![DS 2025-03-20 at 11 19 36@2x](https://github.com/user-attachments/assets/fed2b611-8c68-483c-93bb-eeb51465ee64) |


**Notes to reviewers**

**How has it been tested?**

Have you tested the following pages?
- [] base.org
- [] base.org/ecosystem
- [] base.org/resources
- [] base.org/build
- [] base.org/names
- [] base.org/name/jesse
- [] base.org/manage-names
