### PR TITLE
chore: add load error handling

### DIFF
--- a/apps/base-docs/docs/layout.tsx
+++ b/apps/base-docs/docs/layout.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import { useEffect, type ReactNode } from 'react';
 import ThemeProvider from './contexts/Theme.tsx';
 import { AppProviders } from './contexts/AppProviders.tsx';
 import { Buffer } from 'buffer';
@@ -7,6 +7,13 @@ import { Buffer } from 'buffer';
 globalThis.Buffer = Buffer;
 
 export default function Layout({ children }: { children: ReactNode }) {
+  useEffect(() => {
+    window.addEventListener('vite:preloadError', handlePreloadError);
+    return () => {
+      window.removeEventListener('vite:preloadError', handlePreloadError);
+    };
+  }, []);
+
   return (
     <div
       className="vocs-layout antialiased"
@@ -19,4 +26,15 @@ export default function Layout({ children }: { children: ReactNode }) {
       </ThemeProvider>
     </div>
   );
+}
+
+/**
+ * https://vite.dev/guide/build#load-error-handling
+ * This is a workaround for a known issue with Vite, where a user who visited
+ * before a new deployment might encounter an import error. This error happens
+ * because the assets running on that user's device are outdated and it tries to
+ * import the corresponding old chunk, which is deleted.
+ */
+function handlePreloadError() {
+  window.location.reload();
 }


### PR DESCRIPTION
**What changed? Why?**
* added load error handler to docs root layout
* per [Vite](https://vite.dev/guide/build#load-error-handling), this handles the issue of outdated assets being delivered to a user after new deploys

**Notes to reviewers**

**How has it been tested?**

Have you tested the following pages?
- [] base.org
- [] base.org/ecosystem
- [] base.org/resources
- [] base.org/build
- [] base.org/names
- [] base.org/name/jesse
- [] base.org/manage-names
