### PR TITLE
chore: update PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,10 +5,16 @@
 **How has it been tested?**
 
 Have you tested the following pages?
+
+BaseWeb
 - [] base.org
-- [] base.org/ecosystem
-- [] base.org/resources
-- [] base.org/build
 - [] base.org/names
+- [] base.org/builders
+- [] base.org/ecosystem
 - [] base.org/name/jesse
 - [] base.org/manage-names
+- [] base.org/resources
+
+BaseDocs
+- [] docs.base.org
+- [] docs sub-pages


### PR DESCRIPTION
**What changed? Why?**
* update PR template to fix /build (should be /builders) and add base docs prompt

**Notes to reviewers**

**How has it been tested?**

Have you tested the following pages?
- [] base.org
- [] base.org/ecosystem
- [] base.org/resources
- [] base.org/build
- [] base.org/names
- [] base.org/name/jesse
- [] base.org/manage-names
