### PR TITLE
@next/codemod@canary next-async-request-api .

### DIFF
--- a/apps/web/app/(basenames)/name/[username]/configure-frames/page.tsx
+++ b/apps/web/app/(basenames)/name/[username]/configure-frames/page.tsx
@@ -7,10 +7,11 @@ import { redirectIfNotNameOwner } from 'apps/web/src/utils/redirectIfNotNameOwne
 import { formatDefaultUsername } from 'apps/web/src/utils/usernames';
 
 export type ConfigureFramesProps = {
-  params: { username: Basename };
+  params: Promise<{ username: Basename }>;
 };
 
-export default async function ConfigureFrames({ params }: ConfigureFramesProps) {
+export default async function ConfigureFrames(props: ConfigureFramesProps) {
+  const params = await props.params;
   let username = await formatDefaultUsername(decodeURIComponent(params.username) as Basename);
   await redirectIfNotNameOwner(username);
 

--- a/apps/web/app/(basenames)/name/[username]/opengraph-image.tsx
+++ b/apps/web/app/(basenames)/name/[username]/opengraph-image.tsx
@@ -24,7 +24,8 @@ const size = {
   height: 630,
 };
 
-export async function generateImageMetadata({ params }: UsernameProfileProps) {
+export async function generateImageMetadata(props: UsernameProfileProps) {
+  const params = await props.params;
   let username = params.username;
   if (
     username &&

--- a/apps/web/app/(basenames)/name/[username]/page.tsx
+++ b/apps/web/app/(basenames)/name/[username]/page.tsx
@@ -12,10 +12,11 @@ import classNames from 'classnames';
 import { Metadata } from 'next';
 
 export type UsernameProfileProps = {
-  params: { username: Basename };
+  params: Promise<{ username: Basename }>;
 };
 
-export async function generateMetadata({ params }: UsernameProfileProps): Promise<Metadata> {
+export async function generateMetadata(props: UsernameProfileProps): Promise<Metadata> {
+  const params = await props.params;
   const username = await formatDefaultUsername(params.username);
   const defaultDescription = `${username}, a Basename`;
   const description = await getBasenameTextRecord(username, UsernameTextRecordKeys.Description);
@@ -34,7 +35,8 @@ export async function generateMetadata({ params }: UsernameProfileProps): Promis
   };
 }
 
-export default async function Username({ params }: UsernameProfileProps) {
+export default async function Username(props: UsernameProfileProps) {
+  const params = await props.params;
   let username = await formatDefaultUsername(decodeURIComponent(params.username) as Basename);
   await redirectIfNotNameOwner(username);
 

--- a/apps/web/app/(basenames)/names/page.tsx
+++ b/apps/web/app/(basenames)/names/page.tsx
@@ -23,8 +23,9 @@ export const metadata: Metadata = {
   },
 };
 
-type PageProps = { searchParams?: { code?: string } };
-export default async function Page({ searchParams }: PageProps) {
+type PageProps = { searchParams?: Promise<{ code?: string }> };
+export default async function Page(props: PageProps) {
+  const searchParams = await props.searchParams;
   const code = searchParams?.code;
 
   return (


### PR DESCRIPTION
**What changed? Why?**

We have been getting this error, and running the codemod to update our `params` usage fixes the problem ahead of next.js's deprecation of the pattern. 

```
Error: Route "/name/[username]" used `params.username`. `params` should be awaited before using its properties. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis
    at username (app/(basenames)/name/[username]/page.tsx:38:71)
  36 |
  37 | export default async function Username({ params }: UsernameProfileProps) {
> 38 |   let username = await formatDefaultUsername(decodeURIComponent(params.username) as Basename);
     |                                                                       ^
  39 |   await redirectIfNotNameOwner(username);
  40 |
  41 |   const usernameProfilePageClasses = classNames(
Error: Route "/name/[username]" used `params.username`. `params` should be awaited before using its properties. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis
    at username (app/(basenames)/name/[username]/page.tsx:19:54)
  17 |
  18 | export async function generateMetadata({ params }: UsernameProfileProps): Promise<Metadata> {
> 19 |   const username = await formatDefaultUsername(params.username);
     |                                                      ^
  20 |   const defaultDescription = `${username}, a Basename`;
  21 |   const description = await getBasenameTextRecord(username, UsernameTextRecordKeys.Description);
  22 |
Error: Route "/name/[username]" used `params.username`. `params` should be awaited before using its properties. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis
    at username (app/(basenames)/name/[username]/page.tsx:29:27)
  27 |     openGraph: {
  28 |       title: `Basenames | ${username}`,
> 29 |       url: `/name/${params.username}`,
     |                           ^
  30 |     },
  31 |     twitter: {
  32 |       card: 'summary_large_image',
 GET /name/jfrankfurt 200 in 427ms
Error: Route "/name/[username]" used `params.username`. `params` should be awaited before using its properties. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis
    at username (app/(basenames)/name/[username]/page.tsx:29:27)
  27 |     openGraph: {
  28 |       title: `Basenames | ${username}`,
> 29 |       url: `/name/${params.username}`,
     |                           ^
  30 |     },
  31 |     twitter: {
  32 |       card: 'summary_large_image',
 HEAD /name/jfrankfurt 200 in 7491ms
 GET /api/proxy?apiType=base-sepolia&address=0x1b871306ec2BA9162618870Fe7d96ba6F2C7688B 200 in 7417ms
Error in API proxy: TypeError: fetch failed
    at async GET (app/(basenames)/api/proxy/route.ts:37:29)
  35 |     }
  36 |
> 37 |     const externalResponse = await fetch(apiUrl, {
     |                             ^
  38 |       method: 'GET',
  39 |       headers: {
  40 |         'Content-Type': 'application/json', {
  [cause]: [Error [ConnectTimeoutError]: Connect Timeout Error] {
    code: 'UND_ERR_CONNECT_TIMEOUT'
  }
}
 GET /api/proxy?apiType=basescan&address=0x1b871306ec2BA9162618870Fe7d96ba6F2C7688B 500 in 14156ms
Error in API proxy: TypeError: fetch failed
    at async GET (app/(basenames)/api/proxy/route.ts:37:29)
  35 |     }
  36 |
> 37 |     const externalResponse = await fetch(apiUrl, {
     |                             ^
  38 |       method: 'GET',
  39 |       headers: {
  40 |         'Content-Type': 'application/json', {
  [cause]: [Error [ConnectTimeoutError]: Connect Timeout Error] {
    code: 'UND_ERR_CONNECT_TIMEOUT'
  }
}

```

**Notes to reviewers**

**How has it been tested?**

Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources

BaseDocs
- [] docs.base.org
- [] docs sub-pages
