### PR TITLE
chore: Add OCK Badge, Identity, and IdentityCard tooltip docs

### DIFF
--- a/apps/base-docs/docs/pages/builderkits/onchainkit/identity/badge.mdx
+++ b/apps/base-docs/docs/pages/builderkits/onchainkit/identity/badge.mdx
@@ -43,9 +43,48 @@ import { Badge } from '@coinbase/onchainkit/identity';
   <Badge className="bg-blue-400 border-white"/>
 </App>
 
+## Badge with Tooltip
+
+You can enable a tooltip for the attestation badge to provide context about what the badge represents:
+
+```tsx twoslash
+// @noErrors: 2657
+import { Badge } from '@coinbase/onchainkit/identity';
+
+<Badge 
+  tooltip={true} // [!code focus]
+  className="badge"
+/>
+```
+
+<App>
+  <Badge tooltip={true} className="badge" />
+</App>
+
+With custom tooltip text:
+
+```tsx twoslash
+// @noErrors: 2657
+import { Badge } from '@coinbase/onchainkit/identity';
+
+<Badge 
+  tooltip="Coinbase Verified Account" // [!code focus]
+  className="badge"
+/>
+```
+
+<App>
+  <Badge tooltip="Coinbase Verified Account" className="badge" />
+</App>
+
 ## Props
 
 [`BadgeReact`](/builderkits/onchainkit/identity/types#badgereact)
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `className` | `string` | Optional className override for top span element |
+| `tooltip` | `boolean \| string` | Controls whether the badge shows a tooltip on hover. When `true`, displays the attestation name. When a string is provided, shows that custom text instead. Defaults to `false` |
 
 ## Badge on `<Name />` and `<Avatar />`
 
@@ -54,6 +93,7 @@ Badge with [`<Name />`](/builderkits/onchainkit/identity/name), best used when [
 In both examples we use the Coinbase [Verified Account](https://base.easscan.org/schema/view/0xf8b05c79f090979bf4a80270aba232dff11a10d9ca55c4f88de95317970f0de9) schema ID to show the Coinbase verified badge on the Name and Avatar components.
 
 ```tsx twoslash
+// @noErrors: 2657
 import { base } from 'viem/chains';
 import { Badge, Name, Identity } from '@coinbase/onchainkit/identity';
 
@@ -67,7 +107,7 @@ const COINBASE_VERIFIED_ACCOUNT_SCHEMA_ID =
   address={address}
 >
   <Name address={address}>
-    <Badge />
+    <Badge tooltip={true} /> {/* With tooltip that shows attestation name */}
   </Name>
 </Identity>
 ```
@@ -78,7 +118,7 @@ const COINBASE_VERIFIED_ACCOUNT_SCHEMA_ID =
     schemaId="0xf8b05c79f090979bf4a80270aba232dff11a10d9ca55c4f88de95317970f0de9"
   >
     <Name address="0x838aD0EAE54F99F1926dA7C3b6bFbF617389B4D9">
-      <Badge />
+      <Badge tooltip={true} />
     </Name>
   </Identity>
 </App>
@@ -86,6 +126,7 @@ const COINBASE_VERIFIED_ACCOUNT_SCHEMA_ID =
 Badge with [`<Avatar />`](/builderkits/onchainkit/identity/avatar), best used when [`<Avatar />`](/builderkits/onchainkit/identity/avatar) is not paired with any labels.
 
 ```tsx twoslash
+// @noErrors: 2657
 import { base } from 'viem/chains';
 import { Avatar, Badge, Identity } from '@coinbase/onchainkit/identity';
 
@@ -98,7 +139,7 @@ const COINBASE_VERIFIED_ACCOUNT_SCHEMA_ID =
   schemaId={COINBASE_VERIFIED_ACCOUNT_SCHEMA_ID}
 >
   <Avatar address={address}>
-    <Badge />
+    <Badge tooltip="Verified by Coinbase" /> {/* With custom tooltip text */}
   </Avatar>
 </Identity>
 ```
@@ -106,7 +147,7 @@ const COINBASE_VERIFIED_ACCOUNT_SCHEMA_ID =
 <App>
   <Identity schemaId="0xf8b05c79f090979bf4a80270aba232dff11a10d9ca55c4f88de95317970f0de9" className="bg-transparent">
     <Avatar address="0x838aD0EAE54F99F1926dA7C3b6bFbF617389B4D9">
-      <Badge />
+      <Badge tooltip="Verified by Coinbase" />
     </Avatar>
   </Identity>
 </App>

--- a/apps/base-docs/docs/pages/builderkits/onchainkit/identity/identity-card.mdx
+++ b/apps/base-docs/docs/pages/builderkits/onchainkit/identity/identity-card.mdx
@@ -22,6 +22,7 @@ The `IdentityCard` component provides a comprehensive way to display user identi
 - **Avatar Support:** Displays ENS and chain-specific avatars
 - **Flexible Display:** Customizable layout and styling options
 - **Chain-Aware:** Works across different EVM chains that support name resolution
+- **Tooltip Support:** Displays attestation information on badge hover
 
 ## Usage
 
@@ -44,6 +45,58 @@ import { base } from 'viem/chains';
     address="0x4bEf0221d6F7Dd0C969fe46a4e9b339a84F52FDF"
     chain={base}
     className="max-w-[300px]"
+  />
+</App>
+
+### Badge Tooltip
+
+You can enable a tooltip for the attestation badge to provide context about what the badge represents:
+
+```tsx twoslash
+// @noErrors: 2305 2657
+import { IdentityCard } from '@coinbase/onchainkit/identity';
+import { base } from 'viem/chains';
+
+<IdentityCard 
+  address="0x4bEf0221d6F7Dd0C969fe46a4e9b339a84F52FDF"
+  chain={base}
+  schemaId="0xf8b05c79f090979bf4a80270aba232dff11a10d9ca55c4f88de95317970f0de9"
+  badgeTooltip={true} // [!code focus]
+/>
+```
+
+<App>
+  <IdentityCard 
+    schemaId="0xf8b05c79f090979bf4a80270aba232dff11a10d9ca55c4f88de95317970f0de9"
+    address="0x4bEf0221d6F7Dd0C969fe46a4e9b339a84F52FDF"
+    chain={base}
+    className="max-w-[300px]"
+    badgeTooltip={true}
+  />
+</App>
+
+You can also provide custom tooltip text:
+
+```tsx twoslash
+// @noErrors: 2305 2657
+import { IdentityCard } from '@coinbase/onchainkit/identity';
+import { base } from 'viem/chains';
+
+<IdentityCard 
+  address="0x4bEf0221d6F7Dd0C969fe46a4e9b339a84F52FDF"
+  chain={base}
+  schemaId="0xf8b05c79f090979bf4a80270aba232dff11a10d9ca55c4f88de95317970f0de9"
+  badgeTooltip="Coinbase Verified" // [!code focus]
+/>
+```
+
+<App>
+  <IdentityCard 
+    schemaId="0xf8b05c79f090979bf4a80270aba232dff11a10d9ca55c4f88de95317970f0de9"
+    address="0x4bEf0221d6F7Dd0C969fe46a4e9b339a84F52FDF"
+    chain={base}
+    className="max-w-[300px]"
+    badgeTooltip="Coinbase Verified"
   />
 </App>
 
@@ -83,13 +136,15 @@ import { mainnet } from 'viem/chains'; // [!code focus]
 
 ## Props
 
-The `IdentityCard` component accepts the following props:
+[`IdentityCardReact`](/builderkits/onchainkit/identity/types#identitycardreact)
 
 | Prop | Type | Description |
 |------|------|-------------|
 | `address` | `string` | The wallet address to display identity for |
 | `chain` | `Chain` | The chain to resolve the identity on |
 | `className` | `string` | Additional CSS classes to apply |
+| `schemaId` | `Address \| null` | The schema ID for attestation |
+| `badgeTooltip` | `boolean \| string` | When `true`, displays the attestation name in tooltip. When a string is provided, shows that custom text instead. Defaults to `false` |
 
 ## Error Handling
 
@@ -104,8 +159,9 @@ The component handles various error states gracefully:
 
 1. Always provide a valid chain object from viem/chains
 2. Handle loading states in parent components when address might be undefined
-4. Implement proper error boundaries in parent components
-5. Consider mobile responsiveness when styling
+3. Implement proper error boundaries in parent components
+4. Consider mobile responsiveness when styling
+5. Use `badgeTooltip` to provide context about what the verification badge represents
 
 ## Related Components
 

--- a/apps/base-docs/docs/pages/builderkits/onchainkit/identity/identity.mdx
+++ b/apps/base-docs/docs/pages/builderkits/onchainkit/identity/identity.mdx
@@ -42,9 +42,76 @@ import { Avatar, Identity, Name, Badge, Address } from '@coinbase/onchainkit/ide
   </Identity>
 </App>
 
+### Badge with Tooltip
+
+You can enable a tooltip for the attestation badge to provide context about what the badge represents:
+
+```tsx twoslash
+import { Avatar, Identity, Name, Badge, Address } from '@coinbase/onchainkit/identity';
+
+<Identity
+  address="0x838aD0EAE54F99F1926dA7C3b6bFbF617389B4D9"
+  schemaId="0xf8b05c79f090979bf4a80270aba232dff11a10d9ca55c4f88de95317970f0de9"
+>
+  <Avatar />
+  <Name> 
+    <Badge 
+      tooltip={true} // [!code focus]
+    />
+  </Name>
+  <Address />
+</Identity>
+```
+
+<App>
+  <Identity
+    address="0x838aD0EAE54F99F1926dA7C3b6bFbF617389B4D9"
+    schemaId="0xf8b05c79f090979bf4a80270aba232dff11a10d9ca55c4f88de95317970f0de9"
+  >
+    <Avatar />
+    <Name>
+      <Badge tooltip={true} />
+    </Name>
+    <Address />
+  </Identity>
+</App>
+
+You can also provide custom tooltip text:
+```tsx twoslash
+// @errors: 2304 2552
+import { Avatar, Identity, Name, Badge, Address } from '@coinbase/onchainkit/identity';
+
+<Identity
+  address="0x838aD0EAE54F99F1926dA7C3b6bFbF617389B4D9"
+  schemaId="0xf8b05c79f090979bf4a80270aba232dff11a10d9ca55c4f88de95317970f0de9"
+>
+  <Avatar />
+  <Name>
+    <Badge 
+      tooltip="Coinbase Verified Account" // [!code focus]
+    />
+  </Name>
+  <Address />
+</Identity>
+```
+
+<App>
+  <Identity
+    address="0x838aD0EAE54F99F1926dA7C3b6bFbF617389B4D9"
+    schemaId="0xf8b05c79f090979bf4a80270aba232dff11a10d9ca55c4f88de95317970f0de9"
+  >
+    <Avatar />
+    <Name>
+      <Badge tooltip="Coinbase Verified Account" />
+    </Name>
+    <Address />
+  </Identity>
+</App>
+
 Modify any styles with `className` prop.
 
 ```tsx twoslash
+// @errors: 2304 2552 2657
 import { Avatar, Identity, Name, Badge, Address } from '@coinbase/onchainkit/identity';
 
 <Identity

--- a/apps/base-docs/docs/pages/builderkits/onchainkit/identity/types.mdx
+++ b/apps/base-docs/docs/pages/builderkits/onchainkit/identity/types.mdx
@@ -50,6 +50,7 @@ type AvatarReact = {
 ```ts
 type BadgeReact = {
   className?: string; // Optional className override for top span element.
+  tooltip?: boolean | string; // Controls whether the badge shows a tooltip on hover. When true, the tooltip displays the attestation's name. When a string is provided, that text overrides the default display. Defaults to false.
 };
 ```
 
@@ -158,6 +159,18 @@ type GetNameReturnType = string | null;
 type GetNames = {
   addresses: Address[]; // Array of Ethereum addresses to resolve names for
   chain?: Chain; // Optional chain for domain resolution
+};
+```
+
+## `IdentityCardReact`
+
+```ts
+type IdentityCardReact = {
+  address?: Address;
+  chain?: Chain;
+  className?: string;
+  schemaId?: Address | null;
+  badgeTooltip?: boolean | string; // Controls whether the badge shows a tooltip on hover. When true, the tooltip displays the attestation's name. When a string is provided, that text overrides the default display. Defaults to false.
 };
 ```
 


### PR DESCRIPTION
**What changed? Why?**
Adding documentation for the following OnchainKit feature - [feat: Add Badge tooltip display](https://github.com/coinbase/onchainkit/pull/2140#top)

The Identity, IdentityCard, and Badge components now support a tooltip parameter. 

**Notes to reviewers**

**How has it been tested?**
<img width="908" alt="Screenshot 2025-03-21 at 1 09 31 PM" src="https://github.com/user-attachments/assets/164f706d-32ab-4509-8130-8476b417f10e" />


<img width="1072" alt="Screenshot 2025-03-21 at 1 09 45 PM" src="https://github.com/user-attachments/assets/c03dfc5f-4ff2-4e24-98e0-293208cdb7e7" />

<img width="723" alt="Screenshot 2025-03-21 at 1 09 57 PM" src="https://github.com/user-attachments/assets/7cf923f1-2730-4dff-b43c-3c3f7be93af1" />

Have you tested the following pages?

BaseWeb
- [x] base.org
- [x] base.org/names
- [x] base.org/builders
- [x] base.org/ecosystem
- [x] base.org/name/jesse
- [x] base.org/manage-names
- [x] base.org/resources

BaseDocs
- [x] docs.base.org
- [x] docs sub-pages
