### PR TITLE
feat: use `base-light` for ock components

### DIFF
--- a/apps/web/app/CryptoProviders.dynamic.tsx
+++ b/apps/web/app/CryptoProviders.dynamic.tsx
@@ -7,7 +7,7 @@ import type { CryptoProvidersProps } from './CryptoProviders';
 export function DynamicCryptoProviders({
   children,
   mode = 'light',
-  theme = 'default',
+  theme = 'base',
 }: CryptoProvidersProps) {
   const [CryptoProvidersDynamic, setCryptoProvidersDynamic] = useState<
     React.ComponentType<{

--- a/apps/web/app/CryptoProviders.tsx
+++ b/apps/web/app/CryptoProviders.tsx
@@ -61,7 +61,7 @@ export type CryptoProvidersProps = {
 export default function CryptoProviders({
   children,
   mode = 'light',
-  theme = 'default',
+  theme = 'base',
 }: CryptoProvidersProps) {
   const onchainKitConfig: AppConfig = useMemo(
     () => ({


### PR DESCRIPTION
**What changed? Why?**
* change onchainkit config to use `base` mode instead of default

**Notes to reviewers**

**How has it been tested?**

Have you tested the following pages?

BaseWeb
- [x] base.org
- [x] base.org/names
- [x] base.org/builders
- [x] base.org/ecosystem
- [x] base.org/name/jesse
- [x] base.org/manage-names
- [x] base.org/resources

BaseDocs
- [x] docs.base.org
- [x] docs sub-pages
