### PR TITLE
Typos fix base web

### DIFF
--- a/apps/base-docs/docs/pages/learn/deployment-to-testnet/contract-verification-sbs.mdx
+++ b/apps/base-docs/docs/pages/learn/deployment-to-testnet/contract-verification-sbs.mdx
@@ -33,7 +33,7 @@ Verifying your contract maps the names of your functions and variables to the co
 
 Click the link. Your contract address is already entered.
 
-Under _Please select Compiler Type_ choose \_Solidity (Single file)
+Under _Please select Compiler Type_ choose Solidity (Single file)
 
 For _Please Select Compiler Version_ select the version matching the `pragma` at the top of your source file. Our examples are currently using _v0.8.17+commit.8df45f5f_.
 

--- a/apps/base-docs/docs/pages/learn/hardhat-forking/hardhat-forking.mdx
+++ b/apps/base-docs/docs/pages/learn/hardhat-forking/hardhat-forking.mdx
@@ -133,7 +133,7 @@ describe('BalanceReader tests', () => {
 
     // Our contract will be able to check the balances of the mainnet deployed contracts and address
     const balance = await instance.getERC20BalanceOf(ARBITRUM_ONE_GATEWAY, USDC_MAINNET_ADDRESS);
-    const balanceAsString = ethers.formatUnits(balance, USDC_DECIMALS);
+    const balanceAsString = ethers.utils.formatUnits(balance, USDC_DECIMALS);
 
     console.log(
       'The USDC Balance of Arbitrum Gateway is $',

--- a/apps/base-docs/docs/pages/use-cases/defi-your-app.mdx
+++ b/apps/base-docs/docs/pages/use-cases/defi-your-app.mdx
@@ -103,7 +103,7 @@ The Swap component uses **Uniswap V3** as the default router, but you can also u
 ### Swap Settings
 The Swap component comes preconfigured but is highly customizable. Just a couple of the settings you can customize:
 - Swap settings
-- bidirectional or unidiectional swaps
+- bidirectional or unidirectional swaps
 - Gasless swaps with paymasters
 
 To learn more about how to customize the Swap component, check out the [Swap docs](/builderkits/onchainkit/swap/swap).

--- a/apps/base-docs/docs/pages/use-cases/launch-ai-agents.mdx
+++ b/apps/base-docs/docs/pages/use-cases/launch-ai-agents.mdx
@@ -13,7 +13,7 @@ import  ElizaInstructions  from './ai-instructions/eliza.mdx'
 # Launch AI Agents
 
 AI Agents are even better when they're onchain! Onchain agents have access to stablecoins, tokens, NFTs, and more. 
-This significnatly increases their autonomy and the universe of tasks they can perform.
+This significantly increases their autonomy and the universe of tasks they can perform.
 
 In this guide, you can select your preferred framework and setup to learn how to launch an AI Agent on Base with CDP Wallet API.
 

--- a/apps/base-docs/docs/pages/use-cases/onboard-any-user.mdx
+++ b/apps/base-docs/docs/pages/use-cases/onboard-any-user.mdx
@@ -123,7 +123,7 @@ Ensure that the Wallet Modal is globally accessible by wrapping your key UI comp
 </AppWithWalletModal>
 
 You now have an interface to streamline user onboarding! The `WalletModal` component handles: 
-- Smart wallet createion for new signups 
+- Smart wallet creation for new signups 
 - Quick connection for existing wallets
 - Wallet connection states
 - Error handling


### PR DESCRIPTION
- Fixed several typos across multiple documents in the Base web documentation.

**What changed? Why?**
- Corrected minor spelling and formatting errors in the following files:
  - `contract-verification-sbs.mdx`: Fixed the phrase "Please select Compiler Type" from `_Solidity (Single file)_` to `Solidity (Single file)`.
  - `hardhat-forking.mdx`: Fixed incorrect method access, replacing `ethers.formatUnits` with `ethers.utils.formatUnits`.
  - `defi-your-app.mdx`: Corrected the misspelling of "unidiectional" to "unidirectional".
  - `launch-ai-agents.mdx`: Fixed the typo "significnatly" to "significantly".
  - `onboard-any-user.mdx`: Corrected the typo "createion" to "creation".

**Notes to reviewers:**
- All changes are purely for typo fixes and should not affect the functionality of the documents. Please review and verify that no content changes were introduced beyond corrections.

**How has it been tested?**
- These changes have been manually reviewed for correctness in spelling and phrasing.
- All relevant documentation pages have been updated and should now be free from typos.

BaseWeb
- [x] base.org
- [x] base.org/names
- [x] base.org/builders
- [x] base.org/ecosystem
- [x] base.org/name/jesse
- [x] base.org/manage-names
- [x] base.org/resources

BaseDocs
- [x] docs.base.org
- [x] docs sub-pages

