### PR TITLE
fix: removes reference to geth archive snapshot

### DIFF
--- a/apps/base-docs/docs/pages/chain/run-a-base-node.mdx
+++ b/apps/base-docs/docs/pages/chain/run-a-base-node.mdx
@@ -87,7 +87,6 @@ In the home directory of your Base Node, create a folder named `geth-data` or `r
 | Testnet | Geth   | Archive       | `wget https://sepolia-archive-snapshots.base.org/$(curl https://sepolia-archive-snapshots.base.org/latest)`           |
 | Testnet | Reth   | Archive       | `wget https://sepolia-reth-archive-snapshots.base.org/$(curl https://sepolia-reth-archive-snapshots.base.org/latest)` |
 | Mainnet | Geth   | Full          | `wget https://mainnet-full-snapshots.base.org/$(curl https://mainnet-full-snapshots.base.org/latest)`                 |
-| Mainnet | Geth   | Archive       | `wget https://mainnet-archive-snapshots.base.org/$(curl https://mainnet-archive-snapshots.base.org/latest)`           |
 | Mainnet | Reth   | Archive       | `wget https://mainnet-reth-archive-snapshots.base.org/$(curl https://mainnet-reth-archive-snapshots.base.org/latest)` |
 
 You'll then need to untar the downloaded snapshot and place the `geth` subfolder inside of it in the `geth-data` folder you created (unless you changed the location of your data directory).

--- a/apps/base-docs/docs/pages/chain/run-a-base-node.mdx
+++ b/apps/base-docs/docs/pages/chain/run-a-base-node.mdx
@@ -84,7 +84,6 @@ In the home directory of your Base Node, create a folder named `geth-data` or `r
 | Network | Client | Snapshot Type | Command                                                                                                               |
 | ------- | ------ | ------------- | --------------------------------------------------------------------------------------------------------------------- |
 | Testnet | Geth   | Full          | `wget https://sepolia-full-snapshots.base.org/$(curl https://sepolia-full-snapshots.base.org/latest)`                 |
-| Testnet | Geth   | Archive       | `wget https://sepolia-archive-snapshots.base.org/$(curl https://sepolia-archive-snapshots.base.org/latest)`           |
 | Testnet | Reth   | Archive       | `wget https://sepolia-reth-archive-snapshots.base.org/$(curl https://sepolia-reth-archive-snapshots.base.org/latest)` |
 | Mainnet | Geth   | Full          | `wget https://mainnet-full-snapshots.base.org/$(curl https://mainnet-full-snapshots.base.org/latest)`                 |
 | Mainnet | Reth   | Archive       | `wget https://mainnet-reth-archive-snapshots.base.org/$(curl https://mainnet-reth-archive-snapshots.base.org/latest)` |


### PR DESCRIPTION
**What changed? Why?**

Base now only support Reth snapshots.

**Notes to reviewers**

**How has it been tested?**

Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources

BaseDocs
- [] docs.base.org
- [] docs sub-pages
