### PR TITLE
chore(run-a-base-node): Re-add snapshot deprecation copy

### DIFF
--- a/apps/base-docs/docs/pages/chain/run-a-base-node.mdx
+++ b/apps/base-docs/docs/pages/chain/run-a-base-node.mdx
@@ -75,6 +75,12 @@ Syncing your node may take **days** and will consume a vast amount of your reque
 
 ### Snapshots
 
+:::info
+
+Geth Archive Snapshots were deprecated on _December 15, 2024_. For Archive nodes, we recommend transitioning to Reth, which offers superior performance for Base’s high-throughput environment. Geth Full and Reth Archive snapshots continue to be maintained and are available below.
+
+:::
+
 If you're a prospective or current Base Node operator and would like to restore from a snapshot to save time on the initial sync, it's possible to always get the latest available snapshot of the Base chain on mainnet and/or testnet by using the following CLI commands. The snapshots are updated every week.
 
 #### Restoring from snapshot
@@ -84,8 +90,10 @@ In the home directory of your Base Node, create a folder named `geth-data` or `r
 | Network | Client | Snapshot Type | Command                                                                                                               |
 | ------- | ------ | ------------- | --------------------------------------------------------------------------------------------------------------------- |
 | Testnet | Geth   | Full          | `wget https://sepolia-full-snapshots.base.org/$(curl https://sepolia-full-snapshots.base.org/latest)`                 |
+| Testnet | Geth   | Archive       | No longer supported                                                                                                   |
 | Testnet | Reth   | Archive       | `wget https://sepolia-reth-archive-snapshots.base.org/$(curl https://sepolia-reth-archive-snapshots.base.org/latest)` |
 | Mainnet | Geth   | Full          | `wget https://mainnet-full-snapshots.base.org/$(curl https://mainnet-full-snapshots.base.org/latest)`                 |
+| Mainnet | Geth   | Archive       | No longer supported                                                                                                   |
 | Mainnet | Reth   | Archive       | `wget https://mainnet-reth-archive-snapshots.base.org/$(curl https://mainnet-reth-archive-snapshots.base.org/latest)` |
 
 You'll then need to untar the downloaded snapshot and place the `geth` subfolder inside of it in the `geth-data` folder you created (unless you changed the location of your data directory).


### PR DESCRIPTION
**What changed? Why?**

This PR adds copy that was overwritten by an older version of this page alongside the recent docs.base.org update. It readds the overwritten copy.

**Notes to reviewers**

N/A

**How has it been tested?**

Localhost

Have you tested the following pages?

BaseWeb
- [x] base.org
- [x] base.org/names
- [x] base.org/builders
- [x] base.org/ecosystem
- [x] base.org/name/jesse
- [x] base.org/manage-names
- [x] base.org/resources

BaseDocs
- [x] docs.base.org
- [x] docs sub-pages
