### PR TITLE
fix broken reown link

### DIFF
--- a/apps/base-docs/docs/pages/identity/smart-wallet/quickstart/quick-demo.mdx
+++ b/apps/base-docs/docs/pages/identity/smart-wallet/quickstart/quick-demo.mdx
@@ -29,7 +29,7 @@ Before running your project, you need to set up your environment variables. Foll
 
 ### Get a ReOwn Project ID
 
-1. Sign up to [ReOwn Cloud](https://www.reown.cloud)
+1. Sign up to [ReOwn Cloud](https://www.reown.com/cloud)
 2. Click on Create, and go through the steps (screenshot below):
    - Name your app (eg. OnchainKit-Template)
    - Select a product - Choose WalletKit


### PR DESCRIPTION
**What changed? Why?**
Incorrect reown link included in quick demo guide

**Notes to reviewers**
One URL Fixed

**How has it been tested?**
Locally

Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources

BaseDocs
- [] docs.base.org
- [] docs sub-pages
