### PR TITLE
Update ecosystem.json

### DIFF
--- a/apps/web/src/data/ecosystem.json
+++ b/apps/web/src/data/ecosystem.json
@@ -34,7 +34,7 @@
   {
     "name": "CoW Swap",
     "description": "CoW Swap is an intent-based meta-DEX aggregator that leverages CoW Protocol's bespoke batch/solver ecosystem. With built in MEV protection, CoW Swap lets traders big and small do more and worry less",
-    "url": "https://swap.cow.fi",
+    "url": "https://swap.cow.fi/#/8453/swap/WETH/0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
     "imageUrl": "/images/partners/cowswap.png",
     "category": "defi",
     "subcategory": "dex aggregator"


### PR DESCRIPTION
Update cowswap link to point to Base instead of Eth

**What changed? Why?**

**Notes to reviewers**

**How has it been tested?**

Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources

BaseDocs
- [] docs.base.org
- [] docs sub-pages
