### PR TITLE
chore: make sub account guide repo easier to find

### DIFF
--- a/apps/base-docs/docs/pages/identity/smart-wallet/guides/sub-accounts/incorporate-spend-permissions.mdx
+++ b/apps/base-docs/docs/pages/identity/smart-wallet/guides/sub-accounts/incorporate-spend-permissions.mdx
@@ -143,7 +143,7 @@ return (
 
 Now that we're finished with creating and storing Spend Permissions, lets use them within our app to actually send a transaction with value.
 
-// Create a file to store the Spend Permission Manager ABI
+Create an [ABI file](https://github.com/montycheese/sub-account-starter-template/blob/master/app/abi.ts) to store the Spend Permission Manager ABI
 
 ```tsx
 // app/abi.ts
@@ -292,3 +292,11 @@ We just updated our sendTransaction function to do a few things. Firstly you pro
 Boot up the app and watch everything work! Remember, you'll need to add at least 0.0001 Base Sepolia ETH to your Coinbase Smart Wallet (not Sub Account) to get this example working!
 
 Need free Base Sepolia ETH? Sign up on the [Coinbase Developer Platform](https://www.coinbase.com/developer-platform) to get access to a faucet.
+
+## Got stuck somewhere and need the final code?
+
+You can find the final, working code [here](https://github.com/montycheese/sub-account-starter-template).
+
+```bash
+git clone https://github.com/montycheese/sub-account-starter-template.git
+```

--- a/apps/base-docs/docs/pages/identity/smart-wallet/guides/sub-accounts/overview.mdx
+++ b/apps/base-docs/docs/pages/identity/smart-wallet/guides/sub-accounts/overview.mdx
@@ -26,9 +26,13 @@ In this guide, we'll set up a basic React app using NextJS that:
 - Requests a Spend Permission for the Sub Account to have a daily allowance
 - Uses the Sub Account to perform popup-less transactions
 
-:::tip[Skip ahead]
+### Skip ahead
+
 Note: if you want to skip ahead and just get the final code, you can find it [here](https://github.com/montycheese/sub-account-starter-template).
-:::
+
+```bash
+git clone https://github.com/montycheese/sub-account-starter-template.git
+```
 
 ## Guide Sections
 

--- a/apps/base-docs/docs/pages/identity/smart-wallet/guides/sub-accounts/setup.mdx
+++ b/apps/base-docs/docs/pages/identity/smart-wallet/guides/sub-accounts/setup.mdx
@@ -14,9 +14,13 @@ By the end of this guide, you will:
 - Set up a NextJS project and configure it to work with Coinbase Smart Wallet
 - Create a Coinbase Wallet Context to manage the state and functions needed to interact with Coinbase Smart Wallet
 
-:::tip[Skip ahead]
+### Skip ahead
+
 Note: if you want to skip ahead and just get the final code, you can find it [here](https://github.com/montycheese/sub-account-starter-template).
-:::
+
+```bash
+git clone https://github.com/montycheese/sub-account-starter-template.git
+```
 
 ## Creating a New Project
 
@@ -67,7 +71,7 @@ app/
 
 This section will walk you through setting up Coinbase Wallet Context to manage the state and functions needed to interact with Coinbase Smart Wallet.
 
-Create a new directory called `context` under the `app` directory and add a React Context for the Coinbase SDK.
+Create a new directory called `context` under the `app` directory and add a React Context for the Coinbase SDK called [CoinbaseWalletContext](https://github.com/montycheese/sub-account-starter-template/blob/master/app/context/CoinbaseWalletContext.tsx).
 
 ```tsx
 // app/context/CoinbaseWalletContext.tsx
@@ -177,7 +181,7 @@ export function useCoinbaseWallet() {
 
 ## Creating the Provider Wrapper
 
-Create a providers file to wrap your application:
+Create a [providers file](https://github.com/montycheese/sub-account-starter-template/blob/master/app/providers.tsx) to wrap your application:
 
 ```tsx
 // app/providers.tsx
@@ -193,12 +197,11 @@ export default function Providers({ children }: { children: ReactNode }) {
 
 ## Updating the Root Layout
 
-Update your root layout to include the providers:
+Update your [root layout file](https://github.com/montycheese/sub-account-starter-template/blob/master/app/layout.tsx) to include the providers:
 
 ```tsx
 // app/layout.tsx
 import Providers from '@/app/providers';
-import { ReactNode } from 'react';
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
@@ -213,7 +216,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
 
 ## Creating the Home Page
 
-Update your main page to include wallet connection functionality:
+Update your [main page](https://github.com/montycheese/sub-account-starter-template/blob/master/app/page.tsx) to include wallet connection functionality:
 
 ```tsx
 // app/page.tsx


### PR DESCRIPTION
**What changed? Why?**
Updated Sub account guide to make it easier to find the final repo that is a reference for the guide. These changes were made based on feedback. 

Specific changes:
1. Link to the repo file directly when referenced
2. Change from using "tip" sections to sub sections to reference guide repo
3. show git command to clone guide repo

**Notes to reviewers**

**How has it been tested?**
Yes. Preview: https://web-base-docs-2gv9rfypd-coinbase-vercel.vercel.app/identity/smart-wallet/guides/sub-accounts/overview

Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources

BaseDocs
- [] docs.base.org
- [] docs sub-pages
