### PR TITLE
fix: slow down "Base is for everyone" marquee

### DIFF
--- a/apps/web/src/components/base-org/root/SlidingTextSection/index.tsx
+++ b/apps/web/src/components/base-org/root/SlidingTextSection/index.tsx
@@ -19,7 +19,7 @@ export default function SlidingTextSection() {
     'before:bg-gradient-to-r before:from-transparent before:to-blue',
   );
 
-  const animationStyles = { '--animation-duration': '20s' } as CSSProperties;
+  const animationStyles = { '--animation-duration': '40s' } as CSSProperties;
 
   return (
     <section>


### PR DESCRIPTION
**What changed? Why?**
* doubled the animation duration of the "Base is for everyone" marquee
  * Base is for everyone, not just speed readers 😂


https://github.com/user-attachments/assets/7144dccb-850d-4235-87b7-5ec99dad0aa1

**Notes to reviewers**

**How has it been tested?**

Have you tested the following pages?

BaseWeb
- [x] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources

BaseDocs
- [] docs.base.org
- [] docs sub-pages
