### PR TITLE
Fix broken get started url on MiniKit product page

### DIFF
--- a/apps/web/src/components/Builders/MiniKit/Hero.tsx
+++ b/apps/web/src/components/Builders/MiniKit/Hero.tsx
@@ -10,7 +10,7 @@ import { HeaderAnimation } from 'apps/web/src/components/Builders/MiniKit/Header
 import minikit from 'apps/web/src/components/Builders/MiniKit/minikit.svg';
 import { Icon } from 'apps/web/src/components/Icon/Icon';
 
-export const GET_STARTED_URL = 'https://docs.base.org/builderkits/minikit/getting-started';
+export const GET_STARTED_URL = 'https://docs.base.org/builderkits/minikit/overview';
 const MINIKIT_COMMAND = 'npx create-onchain@alpha --mini';
 
 export function Hero() {


### PR DESCRIPTION
**What changed? Why?**
Fixed broken Get Started URL

**Notes to reviewers**

**How has it been tested?**

Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources

BaseDocs
- [] docs.base.org
- [] docs sub-pages
