### PR TITLE
fix: fix default kv url

### DIFF
--- a/apps/web/src/utils/kv/index.ts
+++ b/apps/web/src/utils/kv/index.ts
@@ -155,7 +155,7 @@ export class KVManager {
 }
 
 function createDefaultKVManager() {
-  const url = process.env.KV_URL_DEVELOPMENT_VERCEL;
+  const url = isDevelopment ? process.env.KV_URL_DEVELOPMENT : process.env.KV_URL;
   if (!url) {
     throw new Error('No KV URL provided');
   }


### PR DESCRIPTION
**What changed? Why?**
* changed the default KV url to handle both dev and prod environments

**Notes to reviewers**

**How has it been tested?**
base.org/api/registry/entries will load data

Have you tested the following pages?

BaseWeb
- [x] base.org
- [x] base.org/names
- [x] base.org/builders
- [x] base.org/ecosystem
- [x] base.org/name/jesse
- [x] base.org/manage-names
- [x] base.org/resources

BaseDocs
- [x] docs.base.org
- [x] docs sub-pages
