### PR TITLE
fix: Remove useTBADeepLink documentation from MiniKit overview

### DIFF
--- a/apps/base-docs/docs/pages/builderkits/minikit/overview.mdx
+++ b/apps/base-docs/docs/pages/builderkits/minikit/overview.mdx
@@ -117,19 +117,6 @@ useEffect(() => {
 }
 ```
 
-### useTBADeepLink
-
-This hook wraps `sdk.actions.openUrl` and provides a map of all available TBA deep links. If a user is not in TBA, this hook will open an external browser and attempt to deep link to the TBA app.
-
-```tsx
-const openBuyLink = useTBADeepLink('buy');
-const openSwapLink = useTBADeepLink('swap');
-
-// Usage
-<button onClick={() => openBuyLink()}>Buy Tokens</button>
-<button onClick={() => openSwapLink()}>Swap Tokens</button>
-```
-
 ### useAddFrame
 
 This hook adds a frame to the user's list of frames and returns notification details.


### PR DESCRIPTION
**What changed? Why?**
Remove useTBADeepLink documentation from MiniKit overview

**Notes to reviewers**

**How has it been tested?**

Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources

BaseDocs
- [] docs.base.org
- [] docs sub-pages
