### PR TITLE
chore: add domain scoping info to sub account doc

### DIFF
--- a/apps/base-docs/docs/pages/identity/smart-wallet/features/sub-accounts.mdx
+++ b/apps/base-docs/docs/pages/identity/smart-wallet/features/sub-accounts.mdx
@@ -20,3 +20,7 @@ In the CoinbaseWalletSDK properties you can set the `keysUrl` to `https://keys-d
 
 If you would like to use Sub Accounts with Coinbase Smart Wallet in our production environment, please [reach out](https://discord.com/invite/buildonbase) to the Base team.
 :::
+
+## Sub Account scope
+
+Sub Accounts are currently scoped to an application's fully qualified domain name (FQDN). This means that a user has one sub account for your application, and it cannot be used on other applications on separate domains.


### PR DESCRIPTION
**What changed? Why?**

Added information about Smart Wallet Sub Accounts scoping 

**Notes to reviewers**

**How has it been tested?**

Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources

BaseDocs
- [] docs.base.org
- [] docs sub-pages
