### PR TITLE
fix: reimplement vercel/kv

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -40,6 +40,7 @@
     "@types/react-calendar-heatmap": "^1.6.7",
     "@types/three": "0.153.0",
     "@vercel/blob": "^0.23.4",
+    "@vercel/kv": "^1.0.1",
     "@vercel/og": "^0.6.2",
     "@vercel/postgres-kysely": "^0.8.0",
     "base-ui": "0.1.1",

--- a/apps/web/pages/api/checkNftProof/index.ts
+++ b/apps/web/pages/api/checkNftProof/index.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { kv } from 'apps/web/src/utils/kv';
+import { kv } from '@vercel/kv';
 import { logger } from 'apps/web/src/utils/logger';
 
 type RequestBody = {

--- a/apps/web/pages/api/registry/entries.ts
+++ b/apps/web/pages/api/registry/entries.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { db } from 'apps/web/src/utils/ocsRegistry';
-import { kv } from 'apps/web/src/utils/kv';
+import { kv } from '@vercel/kv';
 import { logger } from 'apps/web/src/utils/logger';
 import { withTimeout } from 'apps/web/pages/api/decorators';
 

--- a/apps/web/pages/api/registry/featured.ts
+++ b/apps/web/pages/api/registry/featured.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { db } from 'apps/web/src/utils/ocsRegistry';
-import { kv } from 'apps/web/src/utils/kv';
+import { kv } from '@vercel/kv';
 import { logger } from 'apps/web/src/utils/logger';
 import { withTimeout } from 'apps/web/pages/api/decorators';
 

--- a/apps/web/src/utils/proofs/sybil_resistance.ts
+++ b/apps/web/src/utils/proofs/sybil_resistance.ts
@@ -1,5 +1,5 @@
 import { getAttestations } from '@coinbase/onchainkit/identity';
-import { kv } from 'apps/web/src/utils/kv';
+import { kv } from '@vercel/kv';
 import { CoinbaseProofResponse } from 'apps/web/pages/api/proofs/coinbase';
 import RegistrarControllerABI from 'apps/web/src/abis/RegistrarControllerABI';
 import {

--- a/yarn.lock
+++ b/yarn.lock
@@ -159,6 +159,7 @@ __metadata:
     "@typescript-eslint/types": ^7.8.0
     "@typescript-eslint/utils": ^7.8.0
     "@vercel/blob": ^0.23.4
+    "@vercel/kv": ^1.0.1
     "@vercel/og": ^0.6.2
     "@vercel/postgres-kysely": ^0.8.0
     autoprefixer: ^10.4.13
@@ -8951,6 +8952,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@upstash/redis@npm:1.25.1":
+  version: 1.25.1
+  resolution: "@upstash/redis@npm:1.25.1"
+  dependencies:
+    crypto-js: ^4.2.0
+  checksum: 694d9ff33b0a4bce95fa72effaface1b9c41cab7093d726fc1a9ef29eb5ac6eda3d4d0cc59c130bc6e62bf20eaa60a8ef423c257bac1484d3d76e73c56a3ea7e
+  languageName: node
+  linkType: hard
+
 "@use-gesture/core@npm:10.3.1":
   version: 10.3.1
   resolution: "@use-gesture/core@npm:10.3.1"
@@ -9102,6 +9112,15 @@ __metadata:
   version: 2.0.3
   resolution: "@vercel/error-utils@npm:2.0.3"
   checksum: cb631bb6cf9574b3f1ee64cca82e9c594fa0a0d44f1fa0e810d86a11a98935cc780b2b89ac303a18609aed3582907142b45a88641d55a15e628e7bea38669f22
+  languageName: node
+  linkType: hard
+
+"@vercel/kv@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@vercel/kv@npm:1.0.1"
+  dependencies:
+    "@upstash/redis": 1.25.1
+  checksum: 399ab8a846406cd61ea03909f04a5261ab0e06bac14e6a834f5292005305d9ee463179579fa74fe554db1cfecb706372bb4e9faa473433a146e2311095f6c29e
   languageName: node
   linkType: hard
 
@@ -11545,6 +11564,13 @@ __metadata:
   dependencies:
     uncrypto: ^0.1.3
   checksum: 390c71a597b410f44e94cc60e247f9beca25d36e863e1a6d8933c5090e70afbd905a263f4af9f737fafd618855ce85790757c98c17f27eaabfbace64b236f157
+  languageName: node
+  linkType: hard
+
+"crypto-js@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "crypto-js@npm:4.2.0"
+  checksum: f051666dbc077c8324777f44fbd3aaea2986f198fe85092535130d17026c7c2ccf2d23ee5b29b36f7a4a07312db2fae23c9094b644cc35f7858b1b4fcaf27774
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**What changed? Why?**
* reverted to vercel/kv implementation
* this enables us to continue to deploy to base/web while we investigate the memory leak issue

**Notes to reviewers**

**How has it been tested?**
<img width="574" alt="image" src="https://github.com/user-attachments/assets/c773c893-57a6-470d-8b9e-76191f083c2a" />


Have you tested the following pages?

BaseWeb
- [x] base.org
- [x] base.org/names
- [x] base.org/builders
- [x] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources

BaseDocs
- [x] docs.base.org
- [x] docs sub-pages
