### PR TITLE
fix(stories): Incorrect link

### DIFF
--- a/apps/web/src/components/Builders/Stories/BottomCta/index.tsx
+++ b/apps/web/src/components/Builders/Stories/BottomCta/index.tsx
@@ -15,7 +15,7 @@ export function BottomCta() {
             linkClassNames="text-base font-medium text-white block"
             buttonClassNames="flex items-center justify-between px-4 py-3 group"
             target="_blank"
-            href="/builders/stories" // TODO: Add link
+            href="https://docs.base.org/quickstart"
             eventName="bottom-cta-get-started"
           >
             <div className="flex w-40 items-center justify-between">


### PR DESCRIPTION
**What changed? Why?**

Updates link that should go to quick start instead of back to stories

**Notes to reviewers**

**How has it been tested?**

Have you tested the following pages?

BaseWeb
- [x] base.org
- [x] base.org/names
- [x] base.org/builders
- [x] base.org/ecosystem
- [x] base.org/name/jesse
- [x] base.org/manage-names
- [x] base.org/resources

BaseDocs
- [x] docs.base.org
- [x] docs sub-pages
