### PR TITLE
Update docs to match new canary

### DIFF
--- a/apps/base-docs/docs/pages/identity/smart-wallet/guides/sub-accounts/creating-sub-accounts.mdx
+++ b/apps/base-docs/docs/pages/identity/smart-wallet/guides/sub-accounts/creating-sub-accounts.mdx
@@ -25,7 +25,7 @@ The Coinbase Smart Wallet SDK provides a browser key signer out of the box, whic
 
 ## Configuring the SDK for Sub Accounts
 
-Include the Sub Account configuration properties in your SDK initialization. In this React web app example, we are passing in `getCryptoKeyAccount` from the SDK for the `subaccount.getSigner` param when initializing the SDK in an React useEffect hook.
+Include the Sub Account configuration properties in your SDK initialization. In this React web app example, we are passing in `getCryptoKeyAccount` from the SDK for the `toSubAccountSigner` param when initializing the SDK in an React useEffect hook.
 
 ```tsx
 // app/context/CoinbaseWalletContext.tsx
@@ -46,9 +46,7 @@ useEffect(() => {
       options: 'smartWalletOnly',
       keysUrl: 'https://keys-dev.coinbase.com/connect',
     },
-    subaccount: {
-      getSigner: getCryptoKeyAccount,
-    },
+    toSubAccountSigner: getCryptoKeyAccount,
   });
 
   setProvider(coinbaseWalletSDK.getProvider());

--- a/apps/base-docs/docs/pages/identity/smart-wallet/sdk/snippets/sdk-parameters.mdx
+++ b/apps/base-docs/docs/pages/identity/smart-wallet/sdk/snippets/sdk-parameters.mdx
@@ -26,13 +26,7 @@ App logo image URL. Favicon is used if unspecified.
 Local paths are not supported for `appLogoUrl` as the logo is presented on another window as popup. Please provide a non-local URL.
 :::
 
-### subaccount (optional)
-
-- Type: `object`
-
-Subaccount configuration. Available version 4.4.0+
-
-#### getSigner
+### toSubAccountSigner (optional)
 
 - Type: `() => Promise<OneOf<LocalAccount, WebAuthnAccount>>`
 

--- a/apps/base-docs/docs/pages/identity/smart-wallet/sdk/sub-account-reference.mdx
+++ b/apps/base-docs/docs/pages/identity/smart-wallet/sdk/sub-account-reference.mdx
@@ -23,11 +23,9 @@ const sdk = createCoinbaseWalletSDK({
   appName: 'My Dapp',
   appLogoUrl: 'https://example.com/logo.png',
   // Set up Sub Account support with a signer function
-  subaccount: {
-    getSigner: async () => {
-      // Return a signer that can be used to authenticate operations
-      return await getCryptoKeyAccount();
-    },
+  toSubAccountSigner: async () => {
+    // Return a signer that can be used to authenticate operations
+    return await getCryptoKeyAccount();
   },
 });
 
@@ -104,9 +102,7 @@ const signature = await provider.request({
 createCoinbaseWalletSDK({
   appName: string,
   appLogoUrl: string,
-  subaccount: {
-    getSigner: () => Promise<{ account: { publicKey: string; address?: string } }>,
-  },
+  toSubAccountSigner: () => Promise<{ account: { publicKey: string; address?: string } }>,
 });
 ```
 
@@ -145,13 +141,13 @@ Parameters:
 
 Returns: `Promise<string>` - Response from the smart contract call
 
-#### `sdk.subaccount.setSigner(getSigner)`
+#### `sdk.subaccount.setSigner(toSubAccountSigner)`
 
 Sets the signer function for Sub Account operations.
 
 Parameters:
 
-- `getSigner`: Function that returns a Promise resolving to a signer object
+- `toSubAccountSigner`: Function that returns a Promise resolving to a signer object
 
 ## Technical Details
 


### PR DESCRIPTION
**What changed? Why?**

Update sub account docs based on API changes

**Notes to reviewers**

n/a

**How has it been tested?**

Manually

Have you tested the following pages?

BaseWeb
- [ ] base.org
- [ ] base.org/names
- [ ] base.org/builders
- [ ] base.org/ecosystem
- [ ] base.org/name/jesse
- [ ] base.org/manage-names
- [ ] base.org/resources

BaseDocs
- [x] docs.base.org
- [ ] docs sub-pages
