### PR TITLE
Update Spend Permission docs

### DIFF
--- a/apps/base-docs/docs/pages/identity/smart-wallet/guides/spend-permissions/overview.mdx
+++ b/apps/base-docs/docs/pages/identity/smart-wallet/guides/spend-permissions/overview.mdx
@@ -38,9 +38,6 @@ A user approves a spend permission by signing an [ERC-712](https://eips.ethereum
 the spend permission properties. This signature and the corresponding spend permission details are then submitted to
 `SpendPermissionManager.approveWithSignature` to approve the spend permission onchain.
 
-Multiple spend permissions can be batched and approved with a single signature by constructing a batch spend permission object
-and approving with `SpendPermissionManager.approveBatchWithSignature`.
-
 ## Revoking
 
 Users can revoke permissions at any time by calling `SpendPermissionManager.revoke`. Revocations are onchain calls that can be

--- a/apps/base-docs/docs/pages/identity/smart-wallet/guides/spend-permissions/overview.mdx
+++ b/apps/base-docs/docs/pages/identity/smart-wallet/guides/spend-permissions/overview.mdx
@@ -43,6 +43,8 @@ the spend permission properties. This signature and the corresponding spend perm
 Users can revoke permissions at any time by calling `SpendPermissionManager.revoke`. Revocations are onchain calls that can be
 batched similar to other ERC-4337 transactions.
 
+Spenders can call `SpendPermissionManager.revokeAsSpender` to revoke their own permissions without requiring user interaction.
+
 Once a spend permission has been revoked, it can never be re-approved. Therefore, if a user wants to re-authorize a revoked spend permission,
 the spender will need to generate a new spend permission that has a unique hash from the original spend permission.
 If the parameters of the new spend permission are identical to the revoked permission, the `salt` field of the permission can be used to generate a unique hash.


### PR DESCRIPTION
**What changed? Why?**
- Removed the note about batch approvals for spend permissions because this isn't true until/unless we implement the necessary changes in the frontend.
- Added a note in the "revoke" section that calls out `revokeAsSpender` as an option for spenders to revoke their own permissions without user interaction, since an app needed this and wasn't aware of the option.

**Notes to reviewers**
Linear issue: https://linear.app/coinbase/issue/BW-1440/update-spend-permissions-docs

**How has it been tested?**

Removed bit about batches
<img width="798" alt="Screenshot 2025-03-28 at 10 48 03 AM" src="https://github.com/user-attachments/assets/65236a95-c727-46f2-b1d8-36c1b5abde82" />

Added bit about `revokeAsSpender`
<img width="738" alt="Screenshot 2025-03-28 at 10 47 33 AM" src="https://github.com/user-attachments/assets/e1b0470e-3955-4f90-8592-94e8e28b756a" />



Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources

BaseDocs
- [] docs.base.org
- [] docs sub-pages
