### PR TITLE
context fix in feature_request.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -13,7 +13,7 @@ body:
     id: problem
     attributes:
       label: Is your feature request related to a problem? Please describe.
-      description: A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+      description: A clear and concise description of what the problem is. e.g., I'm always frustrated when [...]
 
   - type: textarea
     id: solution
@@ -33,5 +33,5 @@ body:
     id: other
     attributes:
       label: Additional context
-      description: Add any other context or screenshots about the feature request here.
+      description: Add any additional context or screenshots about the feature request here.
 


### PR DESCRIPTION
-Context structure change from "ex. " to "e.g.,"
-Grammar in "additional context"

**What changed? Why?** 
"ex." to "e.g.,"
"E.g." means for example, you use "e.g.," to introduce examples of something.
while
"Ex." is short for "exercise.", "ex." is used to introduce exercises.

**Notes to reviewers**

**How has it been tested?**

Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources

BaseDocs
- [] docs.base.org
- [] docs sub-pages
