### PR TITLE
docs: Remove warning about SIWF

### DIFF
--- a/apps/base-docs/docs/pages/builderkits/minikit/overview.mdx
+++ b/apps/base-docs/docs/pages/builderkits/minikit/overview.mdx
@@ -9,14 +9,14 @@ description: Easiest way to build Mini Apps on Base
   src="/images/minikit/minikit-cli.gif"
   height="364"/>
 
-MiniKit is easiest way to build Mini Apps on Base, allowing developers to easily build applications without needing to know the details of the SDK implementation. It integrates seamlessly with OnchainKit components and provides Coinbase Wallet-specific hooks that degrade gracefully on other clients such as Warpcast.
+MiniKit is easiest way to build Mini Apps on Base, allowing developers to easily build applications without needing to know the details of the SDK implementation. It integrates seamlessly with OnchainKit components and provides Coinbase Wallet-specific hooks.
 
 ## Why MiniKit?
 
 MiniKit streamlines mini-app development by providing a comprehensive toolkit that makes complex Frames SDK interactions intuitive:
 
 - **Simplified Development:** Build apps with minimal knowledge of the Frames SDK
-- **Coinbase Wallet Integration:** Access Coinbase Wallet-specific hooks that degrade gracefully on other clients
+- **Coinbase Wallet Integration:** Access Coinbase Wallet-specific hooks
 - **Component Compatibility:** Use [OnchainKit](https://onchainkit.xyz/) components out of the box with MiniKit
 - **Automatic Setup:** CLI tool for quick project scaffolding with webhooks and notifications
 - **Account Association:** Simplified generation of account associations


### PR DESCRIPTION
**What changed? Why?**
Remove warning about SIWF and interim AuthKit solution from MiniKit overview documentation

**Notes to reviewers**

**How has it been tested?**

Have you tested the following pages?

BaseWeb
- [x] base.org
- [x] base.org/names
- [x] base.org/builders
- [x] base.org/ecosystem
- [x] base.org/name/jesse
- [x] base.org/manage-names
- [x] base.org/resources

BaseDocs
- [x] docs.base.org
- [x] docs sub-pages
