### PR TITLE
Add AI docs button to the hero section

### DIFF
--- a/apps/web/src/components/Builders/Landing/Hero/index.tsx
+++ b/apps/web/src/components/Builders/Landing/Hero/index.tsx
@@ -95,6 +95,16 @@ export function Hero() {
               >
                 Accept crypto payments
               </ButtonWithLinkAndEventLogging>
+              <ButtonWithLinkAndEventLogging
+                variant={ButtonVariants.SecondaryOutline}
+                iconName="ai"
+                buttonClassNames="rounded-xl text-sm font-medium"
+                href="https://docs.base.org/llms.txt"
+                eventName="accept-crypto-payments"
+                target="_blank"
+              >
+                Start with AI docs
+              </ButtonWithLinkAndEventLogging>
             </div>
 
             <div className="relative w-full max-sm:hidden">


### PR DESCRIPTION
**What changed? Why?**
- Added another entry point to llms.txt (ideally
<img width="760" alt="Screenshot 2025-03-31 at 3 19 06 PM" src="https://github.com/user-attachments/assets/6044e3dc-ca36-4cb9-b16c-25392bd0f6
<img width="487" alt="Screenshot 2025-03-31 at 3 19 20 PM" src="https://github.com/user-attachments/assets/56be04d4-4d95-47b5-9332-1e075c026ff6" />
6a" />

**Notes to reviewers**
- A follow up to this is a tried & tested walk-through page on docs on how to use llms.txt to start building an app 

**How has it been tested?**
- Locally on mobile & web

Have you tested the following pages?

BaseWeb
- [x] base.org
- [x] base.org/names
- [x] base.org/builders
- [x] base.org/ecosystem
- [x] base.org/name/jesse
- [x] base.org/manage-names
- [x] base.org/resources

BaseDocs
- [x] docs.base.org
- [x] docs sub-pages
