### PR TITLE
chore: Update WalletModal docs to support Rabby, Frame, and Trust wallet connection

### DIFF
--- a/apps/base-docs/docs/pages/builderkits/onchainkit/wallet/wallet-modal.mdx
+++ b/apps/base-docs/docs/pages/builderkits/onchainkit/wallet/wallet-modal.mdx
@@ -54,11 +54,10 @@ import AppWithWalletModal from '@/components/AppWithWalletModal';
       mode: 'auto',                 // 'light' | 'dark' | 'auto'
       theme: 'default',             // 'default' or custom theme
     },
-    wallet: {
-      display: 'modal',
-      termsUrl: 'https://example.com/terms',
-      privacyUrl: 'https://example.com/privacy',
-    },
+    wallet: { // [!code focus]
+      display: 'modal', // [!code focus]
+      termsUrl: 'https://...', // [!code focus]
+      privacyUrl: 'https://...', // [!code focus]
   }}
 >
   {children}
@@ -146,8 +145,8 @@ By default, the wallet modal includes Coinbase Wallet, MetaMask, and Phantom as 
     },
     wallet: {
       display: 'modal',
-      termsUrl: 'https://example.com/terms',
-      privacyUrl: 'https://example.com/privacy',
+      termsUrl: 'https://...',
+      privacyUrl: 'https://...',
       supportedWallets: { // [!code focus]
         rabby: true, // [!code focus]
         trust: true, // [!code focus]

--- a/apps/base-docs/docs/pages/builderkits/onchainkit/wallet/wallet-modal.mdx
+++ b/apps/base-docs/docs/pages/builderkits/onchainkit/wallet/wallet-modal.mdx
@@ -3,7 +3,7 @@ title: Wallet Modal · OnchainKit
 description: The Wallet Modal provides users with multiple wallet connection options in a polished interface.
 ---
 
-import { 
+import {
   ConnectWallet,
   Wallet,
   WalletDropdown,
@@ -29,11 +29,13 @@ import AppWithWalletModal from '@/components/AppWithWalletModal';
   className="mx-auto"
 />
 
-`WalletModal` offers users multiple wallet connection options. The modal automatically appears when users click the `ConnectWallet` component and provides three distinct connection paths:
+`WalletModal` offers users multiple wallet connection options. The modal automatically appears when users click the `ConnectWallet` component and provides several connection paths:
 
 1. Quickly create a new smart wallet for new users
 2. Coinbase Wallet connection (supporting both smart wallets and EOA)
-3. MetaMask and Phantom connection
+3. MetaMask connection
+4. Phantom connection
+5. Rabby, Frame, and Trust Wallet connections (optional)
 
 ## Walkthrough
 
@@ -52,10 +54,10 @@ import AppWithWalletModal from '@/components/AppWithWalletModal';
       mode: 'auto',                 // 'light' | 'dark' | 'auto'
       theme: 'default',             // 'default' or custom theme
     },
-    wallet: { // [!code focus]
-      display: 'modal', // [!code focus]
-      termsUrl: 'https://...', // [!code focus]
-      privacyUrl: 'https://...', // [!code focus]
+    wallet: {
+      display: 'modal',
+      termsUrl: 'https://example.com/terms',
+      privacyUrl: 'https://example.com/privacy',
     },
   }}
 >
@@ -116,6 +118,7 @@ The Wallet Modal components are designed to work together hierarchically:
   - Coinbase Wallet connection
   - MetaMask connection
   - Phantom connection
+  - Rabby, Trust, and Frame Wallet connections (if enabled)
   - Terms and privacy policy links
 
 The modal automatically handles:
@@ -126,4 +129,36 @@ The modal automatically handles:
 - Theme customization
 - Terms/privacy policy display
 
+## Additional Wallet Support
+
+By default, the wallet modal includes Coinbase Wallet, MetaMask, and Phantom as connection options. You can enable additional wallet support by configuring the `supportedWallets` object in the `OnchainKitProvider`:
+
+```tsx
+<OnchainKitProvider
+  apiKey={process.env.ONCHAINKIT_API_KEY}
+  chain={base}
+  config={{
+    appearance: {
+      name: 'Your App Name',
+      logo: 'https://your-logo.com',
+      mode: 'auto',
+      theme: 'default',
+    },
+    wallet: {
+      display: 'modal',
+      termsUrl: 'https://example.com/terms',
+      privacyUrl: 'https://example.com/privacy',
+      supportedWallets: { // [!code focus]
+        rabby: true, // [!code focus]
+        trust: true, // [!code focus]
+        frame: true, // [!code focus]
+      }, // [!code focus]
+    },
+  }}
+>
+  {children}
+</OnchainKitProvider>
+```
+
+Each wallet can be individually enabled or disabled as needed. If no `supportedWallets` configuration is provided, the additional wallets will be disabled by default.
 ::::

--- a/apps/base-docs/docs/pages/builderkits/onchainkit/wallet/wallet-modal.mdx
+++ b/apps/base-docs/docs/pages/builderkits/onchainkit/wallet/wallet-modal.mdx
@@ -58,6 +58,7 @@ import AppWithWalletModal from '@/components/AppWithWalletModal';
       display: 'modal', // [!code focus]
       termsUrl: 'https://...', // [!code focus]
       privacyUrl: 'https://...', // [!code focus]
+      },
   }}
 >
   {children}


### PR DESCRIPTION
**What changed? Why?**
Updated the `WalletModal` docs to show additional wallet support feature for `Rabby`, `Trust`, and `Frame` wallet. These can be enabled through the new `OnchainKitProvider` `supportedWallets` parameter.

Update WalletModal docs after this source code change - [feat: Add Rabby, Trust, and Frame wallet connection support](https://github.com/coinbase/onchainkit/pull/2178#top)


**Notes to reviewers**

**How has it been tested?**
<img width="733" alt="Screenshot 2025-03-31 at 3 15 27 PM" src="https://github.com/user-attachments/assets/78161258-5cfc-4f05-b499-5b47c525797a" />

Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources

BaseDocs
- [] docs.base.org
- [] docs sub-pages
