### PR TITLE
fix: add redirect for broken link in Smart Wallet docs

### DIFF
--- a/apps/base-docs/docs/public/serve.json
+++ b/apps/base-docs/docs/public/serve.json
@@ -33,6 +33,10 @@
     {
       "source": "/docs/arbitration",
       "destination": "/arbitration"
+    },
+    {
+      "source": "/identity/smart-wallet/guides/react-native-integration",
+      "destination": "/identity/smart-wallet/quickstart/react-native-project"
     }
   ]
 }


### PR DESCRIPTION
**What changed? Why?**

https://docs.base.org/identity/smart-wallet/guides/react-native-integration is outdated and should redirect to https://docs.base.org/identity/smart-wallet/quickstart/react-native-project

**Notes to reviewers**

**How has it been tested?**

Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources

BaseDocs
- [] docs.base.org
- [] docs sub-pages
