### PR TITLE
Update docs overview page to direct MiniKit card to MiniKit Overview

### DIFF
--- a/apps/base-docs/docs/pages/index.mdx
+++ b/apps/base-docs/docs/pages/index.mdx
@@ -119,7 +119,7 @@ import { paymasterSvg } from '@/components/svg/paymasterSvg';
             title="MiniKit"
             description="Feature your mini app on Warpcast and Coinbase Wallet with a few lines of code.."
             icon={miniKitSvg}
-            href="https://replit.com/@tina-he/ock-frames-template?v=1#README.md"
+            href="/builderkits/minikit/overview"
           />
           <BrowseCard
             title="Verifications"


### PR DESCRIPTION
**What changed? Why?**
The MiniKit card on the docs homepage was still pointing at the old Replit. Updated the href so that it points to the overview page in the MiniKit section of docs


