### PR TITLE
OnchainKit Docs: latest

### DIFF
--- a/apps/base-docs/package.json
+++ b/apps/base-docs/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@coinbase/cookie-banner": "^1.0.3",
     "@coinbase/cookie-manager": "^1.1.1",
-    "@coinbase/onchainkit": "^0.38.2",
+    "@coinbase/onchainkit": "^0.38.3",
     "@coinbase/wallet-sdk-canary": "npm:@coinbase/wallet-sdk@4.4.0-canary.1",
     "@googleapis/sheets": "^5.0.5",
     "@types/react": "latest",

--- a/apps/base-docs/package.json
+++ b/apps/base-docs/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@coinbase/cookie-banner": "^1.0.3",
     "@coinbase/cookie-manager": "^1.1.1",
-    "@coinbase/onchainkit": "^0.38.3",
+    "@coinbase/onchainkit": "^0.38.4",
     "@coinbase/wallet-sdk-canary": "npm:@coinbase/wallet-sdk@4.4.0-canary.1",
     "@googleapis/sheets": "^5.0.5",
     "@types/react": "latest",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@coinbase/cookie-banner": "^1.0.3",
     "@coinbase/cookie-manager": "^1.1.1",
-    "@coinbase/onchainkit": "^0.38.2",
+    "@coinbase/onchainkit": "^0.38.3",
     "@datadog/browser-logs": "^5.23.3",
     "@datadog/browser-rum": "^5.23.3",
     "@frames.js/render": "^0.5.5",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@coinbase/cookie-banner": "^1.0.3",
     "@coinbase/cookie-manager": "^1.1.1",
-    "@coinbase/onchainkit": "^0.38.3",
+    "@coinbase/onchainkit": "^0.38.4",
     "@datadog/browser-logs": "^5.23.3",
     "@datadog/browser-rum": "^5.23.3",
     "@frames.js/render": "^0.5.5",

--- a/apps/web/src/hooks/useBaseEnsName.ts
+++ b/apps/web/src/hooks/useBaseEnsName.ts
@@ -1,7 +1,6 @@
 import { Address, isAddress } from 'viem';
 import useBasenameChain from 'apps/web/src/hooks/useBasenameChain';
-import { Basename, GetNameReturnType, useName } from '@coinbase/onchainkit/identity';
-import { UseQueryResult } from '@tanstack/react-query';
+import { Basename, useName } from '@coinbase/onchainkit/identity';
 
 export type UseBaseEnsNameProps = {
   address?: Address;
@@ -22,7 +21,7 @@ export default function useBaseEnsName({ address }: UseBaseEnsNameProps) {
     {
       enabled: !!address && isAddress(address),
     },
-  ) as UseQueryResult<GetNameReturnType, Error>;
+  );
 
   const ensNameTyped = data ? (data as Basename) : undefined;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -87,7 +87,7 @@ __metadata:
   dependencies:
     "@coinbase/cookie-banner": ^1.0.3
     "@coinbase/cookie-manager": ^1.1.1
-    "@coinbase/onchainkit": ^0.38.3
+    "@coinbase/onchainkit": ^0.38.4
     "@coinbase/wallet-sdk-canary": "npm:@coinbase/wallet-sdk@4.4.0-canary.1"
     "@googleapis/sheets": ^5.0.5
     "@types/next": ^9.0.0
@@ -124,7 +124,7 @@ __metadata:
   dependencies:
     "@coinbase/cookie-banner": ^1.0.3
     "@coinbase/cookie-manager": ^1.1.1
-    "@coinbase/onchainkit": ^0.38.3
+    "@coinbase/onchainkit": ^0.38.4
     "@datadog/browser-logs": ^5.23.3
     "@datadog/browser-rum": ^5.23.3
     "@frames.js/render": ^0.5.5
@@ -1845,9 +1845,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@coinbase/onchainkit@npm:^0.38.3":
-  version: 0.38.3
-  resolution: "@coinbase/onchainkit@npm:0.38.3"
+"@coinbase/onchainkit@npm:^0.38.4":
+  version: 0.38.4
+  resolution: "@coinbase/onchainkit@npm:0.38.4"
   dependencies:
     "@farcaster/frame-core": ^0.0.26
     "@farcaster/frame-sdk": ^0.0.28
@@ -1865,7 +1865,7 @@ __metadata:
     "@types/react": ^18 || ^19
     react: ^18 || ^19
     react-dom: ^18 || ^19
-  checksum: 945fbaca8f2ddf865b6cc8af99a2e4b1cffd8daa3c55e2e263d935b694191bbeeebe7c2182e05d0ac86d23f11a5a954a4ea23e21c4dbd55e811ebe67c984a20f
+  checksum: 99abe1bc50106e9b4009901607966a6084731e799484bd172ae8975333aa63171cdea556dfe91b1c7720ab00e17be7d53ad19c5e5769d1a1950f704ab72f3c10
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -87,7 +87,7 @@ __metadata:
   dependencies:
     "@coinbase/cookie-banner": ^1.0.3
     "@coinbase/cookie-manager": ^1.1.1
-    "@coinbase/onchainkit": ^0.38.2
+    "@coinbase/onchainkit": ^0.38.3
     "@coinbase/wallet-sdk-canary": "npm:@coinbase/wallet-sdk@4.4.0-canary.1"
     "@googleapis/sheets": ^5.0.5
     "@types/next": ^9.0.0
@@ -124,7 +124,7 @@ __metadata:
   dependencies:
     "@coinbase/cookie-banner": ^1.0.3
     "@coinbase/cookie-manager": ^1.1.1
-    "@coinbase/onchainkit": ^0.38.2
+    "@coinbase/onchainkit": ^0.38.3
     "@datadog/browser-logs": ^5.23.3
     "@datadog/browser-rum": ^5.23.3
     "@frames.js/render": ^0.5.5
@@ -1845,26 +1845,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@coinbase/onchainkit@npm:^0.38.2":
-  version: 0.38.2
-  resolution: "@coinbase/onchainkit@npm:0.38.2"
+"@coinbase/onchainkit@npm:^0.38.3":
+  version: 0.38.3
+  resolution: "@coinbase/onchainkit@npm:0.38.3"
   dependencies:
+    "@farcaster/frame-core": ^0.0.26
     "@farcaster/frame-sdk": ^0.0.28
     "@farcaster/frame-wagmi-connector": ^0.0.16
     "@tanstack/react-query": ^5
+    "@wagmi/core": ^2.16.7
     clsx: ^2.1.1
     graphql: ^14 || ^15 || ^16
     graphql-request: ^6.1.0
     qrcode: ^1.5.4
     tailwind-merge: ^2.3.0
-    tailwindcss-animate: ^1.0.7
     viem: ^2.23.0
     wagmi: ^2.14.11
   peerDependencies:
     "@types/react": ^18 || ^19
     react: ^18 || ^19
     react-dom: ^18 || ^19
-  checksum: f0dbb3cbb2cca74f7f992b736f1debcac7dbdcb615834f129c443fb27f4bf294cdef6b6f0ac908e2e67be801796612629c4bf3d82fd004fa24401a3a8775490c
+  checksum: 945fbaca8f2ddf865b6cc8af99a2e4b1cffd8daa3c55e2e263d935b694191bbeeebe7c2182e05d0ac86d23f11a5a954a4ea23e21c4dbd55e811ebe67c984a20f
   languageName: node
   linkType: hard
 
@@ -3185,7 +3186,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@farcaster/frame-core@npm:0.0.26":
+"@farcaster/frame-core@npm:0.0.26, @farcaster/frame-core@npm:^0.0.26":
   version: 0.0.26
   resolution: "@farcaster/frame-core@npm:0.0.26"
   dependencies:
@@ -8978,6 +8979,26 @@ __metadata:
     typescript:
       optional: true
   checksum: ed110e48ed5921d92adf598bc57fc5eac39d11a793fba70e813c8228940116d0f95963e25eee73a8f95572c34630ff3715e93f93b05008f9dcaaaff3ed9676f3
+  languageName: node
+  linkType: hard
+
+"@wagmi/core@npm:^2.16.7":
+  version: 2.16.7
+  resolution: "@wagmi/core@npm:2.16.7"
+  dependencies:
+    eventemitter3: 5.0.1
+    mipd: 0.0.7
+    zustand: 5.0.0
+  peerDependencies:
+    "@tanstack/query-core": ">=5.0.0"
+    typescript: ">=5.0.4"
+    viem: 2.x
+  peerDependenciesMeta:
+    "@tanstack/query-core":
+      optional: true
+    typescript:
+      optional: true
+  checksum: a1497934a59ad35b512c9d772e3f9b103a860e245879b413161cf5fe9f897a2f69f79fd5ec464c20cc6bb6c47291958e036e1c26d44eaab853bf19745cb77df9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**What changed? Why?**
Updating the OnchainKit docs to their latest version - v0.38.3
**Notes to reviewers**

**How has it been tested?**

Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources

BaseDocs
- [] docs.base.org
- [] docs sub-pages
