### PR TITLE
chore: replace rainbowkit with onchainkit's WalletModal

### DIFF
--- a/apps/web/app/CryptoProviders.tsx
+++ b/apps/web/app/CryptoProviders.tsx
@@ -1,47 +1,19 @@
 'use client';
 
 import { AppConfig, OnchainKitProvider } from '@coinbase/onchainkit';
-import { connectorsForWallets, RainbowKitProvider } from '@rainbow-me/rainbowkit';
-import {
-  coinbaseWallet,
-  metaMaskWallet,
-  phantomWallet,
-  rainbowWallet,
-  uniswapWallet,
-  walletConnectWallet,
-} from '@rainbow-me/rainbowkit/wallets';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useMemo } from 'react';
 import { createConfig, http, WagmiProvider } from 'wagmi';
 import { base, baseSepolia, mainnet } from 'wagmi/chains';
 import { isDevelopment } from 'apps/web/src/constants';
 
-const connectors = connectorsForWallets(
-  [
-    {
-      groupName: 'Recommended',
-      wallets: [
-        coinbaseWallet,
-        metaMaskWallet,
-        uniswapWallet,
-        rainbowWallet,
-        phantomWallet,
-        walletConnectWallet,
-      ],
-    },
-  ],
-  {
-    projectId: process.env.NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID ?? 'dummy-id',
-    walletConnectParameters: {},
-    appName: 'Base.org',
-    appDescription: '',
-    appUrl: 'https://www.base.org/',
-    appIcon: '',
-  },
-);
+export type CryptoProvidersProps = {
+  children: React.ReactNode;
+  mode?: 'light' | 'dark';
+  theme?: 'default' | 'base' | 'cyberpunk' | 'hacker';
+};
 
 const config = createConfig({
-  connectors,
   chains: [base, baseSepolia, mainnet],
   transports: {
     [base.id]: http(),
@@ -51,12 +23,6 @@ const config = createConfig({
   ssr: true,
 });
 const queryClient = new QueryClient();
-
-export type CryptoProvidersProps = {
-  children: React.ReactNode;
-  mode?: 'light' | 'dark';
-  theme?: 'default' | 'base' | 'cyberpunk' | 'hacker';
-};
 
 export default function CryptoProviders({
   children,
@@ -71,6 +37,10 @@ export default function CryptoProviders({
       },
       wallet: {
         display: 'modal',
+        supportedWallets: {
+          rabby: true,
+          trust: true,
+        },
       },
     }),
     [mode, theme],
@@ -85,7 +55,7 @@ export default function CryptoProviders({
           config={onchainKitConfig}
           projectId={process.env.NEXT_PUBLIC_CDP_PROJECT_ID}
         >
-          <RainbowKitProvider modalSize="compact">{children}</RainbowKitProvider>
+          {children}
         </OnchainKitProvider>
       </QueryClientProvider>
     </WagmiProvider>

--- a/apps/web/app/global.css
+++ b/apps/web/app/global.css
@@ -2,7 +2,6 @@
 @tailwind components;
 @tailwind utilities;
 
-@import '@rainbow-me/rainbowkit/styles.css';
 @import '@coinbase/onchainkit/styles.css';
 
 /* For Webkit-based browsers (Chrome, Safari and Opera) */

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -29,7 +29,6 @@
     "@radix-ui/react-collapsible": "^1.1.0",
     "@radix-ui/react-popover": "^1.1.1",
     "@radix-ui/react-tooltip": "^1.1.2",
-    "@rainbow-me/rainbowkit": "^2.1.5",
     "@react-three/drei": "^9.113.0",
     "@react-three/fiber": "^9.0.0-alpha.8",
     "@react-three/postprocessing": "^3.0.0-rc.0",

--- a/apps/web/src/components/Basenames/ConfigureFramesPageContent/FrameBuilder.tsx
+++ b/apps/web/src/components/Basenames/ConfigureFramesPageContent/FrameBuilder.tsx
@@ -23,6 +23,7 @@ import mintMe from './ui/mint-me.svg';
 import nftProduct from './ui/nftProduct.svg';
 import previewBackground from './ui/preview-background.svg';
 import emptyPreviewFrame from './ui/preview-frame.svg';
+import { WalletModal } from '@coinbase/onchainkit/wallet';
 
 export default function FrameBuilder() {
   const params = useParams();
@@ -111,7 +112,8 @@ export default function FrameBuilder() {
     [logEventWithContext],
   );
 
-  const { pendingFrameChange, addFrame } = useFrameContext();
+  const { frameConfig, pendingFrameChange, addFrame } = useFrameContext();
+  const { isConnectModalOpen, closeConnectModal } = frameConfig;
 
   const handlePaycasterClick = useCallback(() => {
     if (basename) {
@@ -363,6 +365,7 @@ export default function FrameBuilder() {
           Show Preview
         </Button>
       </SuggestionCard>
+      <WalletModal isOpen={isConnectModalOpen} onClose={closeConnectModal} />
     </>
   );
 

--- a/apps/web/src/components/Basenames/UsernameProfileSectionFrames/Context.tsx
+++ b/apps/web/src/components/Basenames/UsernameProfileSectionFrames/Context.tsx
@@ -13,7 +13,6 @@ import {
   useFarcasterIdentity,
 } from '@frames.js/render/identity/farcaster';
 import { useFrame } from '@frames.js/render/use-frame';
-import { useConnectModal } from '@rainbow-me/rainbowkit';
 import { useAnalytics } from 'apps/web/contexts/Analytics';
 import { useErrors } from 'apps/web/contexts/Errors';
 import L2ResolverAbi from 'apps/web/src/abis/L2Resolver';
@@ -24,6 +23,7 @@ import useReadBaseEnsTextRecords from 'apps/web/src/hooks/useReadBaseEnsTextReco
 import { UsernameTextRecordKeys } from 'apps/web/src/utils/usernames';
 import { ActionType } from 'libs/base-ui/utils/logEvent';
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { useBoolean } from 'usehooks-ts';
 import { EstimateGasExecutionError, namehash } from 'viem';
 import { useAccount, useChainId, useConfig, useWriteContract } from 'wagmi';
 import { sendTransaction, signTypedData, switchChain } from 'wagmi/actions';
@@ -57,6 +57,8 @@ export type FrameContextValue = {
     'homeframeUrl' | 'signerState' | 'frameContext'
   > & {
     frameContext: FarcasterFrameContext;
+    isConnectModalOpen: boolean;
+    closeConnectModal: () => void;
   };
   farcasterSignerState: FarcasterSignerInstance;
   anonSignerState: SignerStateInstance<AnonymousSigner>;
@@ -113,7 +115,7 @@ export function FramesProvider({ children }: FramesProviderProps) {
 
   const currentChainId = useChainId();
   const config = useConfig();
-  const { openConnectModal } = useConnectModal();
+  const { value: isConnectModalOpen, setTrue: openConnectModal, setFalse: closeConnectModal } = useBoolean();
 
   const onTransaction: OnTransactionFunc = useCallback(
     async ({ transactionData, frame }) => {
@@ -281,6 +283,8 @@ export function FramesProvider({ children }: FramesProviderProps) {
         onError,
         onSignature,
         onConnectWallet: openConnectModal,
+        isConnectModalOpen,
+        closeConnectModal,
         frameContext: farcasterFrameContext,
       },
       showFarcasterQRModal,
@@ -308,6 +312,8 @@ export function FramesProvider({ children }: FramesProviderProps) {
       removeFrame,
       existingTextRecordsIsLoading,
       optimisticFrameUrls,
+      isConnectModalOpen,
+      closeConnectModal,
     ],
   );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -138,7 +138,6 @@ __metadata:
     "@radix-ui/react-collapsible": ^1.1.0
     "@radix-ui/react-popover": ^1.1.1
     "@radix-ui/react-tooltip": ^1.1.2
-    "@rainbow-me/rainbowkit": ^2.1.5
     "@react-three/drei": ^9.113.0
     "@react-three/fiber": ^9.0.0-alpha.8
     "@react-three/postprocessing": ^3.0.0-rc.0
@@ -1842,6 +1841,30 @@ __metadata:
     "@coinbase/cookie-manager": 1.1.0
     js-cookie: ^3.0.5
   checksum: 20a67646cf1f37a1db0eb0b2e2e6989f6f34b1a4881d81dead1829b44fe7400f2acf2ebdf2da049ce9804fca4b6f07e6b71b9fe44ffe01c231c1c95f01ea466a
+  languageName: node
+  linkType: hard
+
+"@coinbase/onchainkit@npm:^0.38.4":
+  version: 0.38.4
+  resolution: "@coinbase/onchainkit@npm:0.38.4"
+  dependencies:
+    "@farcaster/frame-core": ^0.0.26
+    "@farcaster/frame-sdk": ^0.0.28
+    "@farcaster/frame-wagmi-connector": ^0.0.16
+    "@tanstack/react-query": ^5
+    "@wagmi/core": ^2.16.7
+    clsx: ^2.1.1
+    graphql: ^14 || ^15 || ^16
+    graphql-request: ^6.1.0
+    qrcode: ^1.5.4
+    tailwind-merge: ^2.3.0
+    viem: ^2.23.0
+    wagmi: ^2.14.11
+  peerDependencies:
+    "@types/react": ^18 || ^19
+    react: ^18 || ^19
+    react-dom: ^18 || ^19
+  checksum: 99abe1bc50106e9b4009901607966a6084731e799484bd172ae8975333aa63171cdea556dfe91b1c7720ab00e17be7d53ad19c5e5769d1a1950f704ab72f3c10
   languageName: node
   linkType: hard
 
@@ -6434,27 +6457,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rainbow-me/rainbowkit@npm:^2.1.5":
-  version: 2.2.4
-  resolution: "@rainbow-me/rainbowkit@npm:2.2.4"
-  dependencies:
-    "@vanilla-extract/css": 1.15.5
-    "@vanilla-extract/dynamic": 2.1.2
-    "@vanilla-extract/sprinkles": 1.6.3
-    clsx: 2.1.1
-    qrcode: 1.5.4
-    react-remove-scroll: 2.6.2
-    ua-parser-js: ^1.0.37
-  peerDependencies:
-    "@tanstack/react-query": ">=5.0.0"
-    react: ">=18"
-    react-dom: ">=18"
-    viem: 2.x
-    wagmi: ^2.9.0
-  checksum: 633854141e3b886302eb825ca888f5ca790d45b847afa729f5e9fb539298d05168e3f034bbe8f4f13da717f42cec0e9d6e7adcaa5aa79073cc213d52c3f489d5
-  languageName: node
-  linkType: hard
-
 "@react-spring/animated@npm:~9.7.5":
   version: 9.7.5
   resolution: "@react-spring/animated@npm:9.7.5"
@@ -8695,26 +8697,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vanilla-extract/css@npm:1.15.5":
-  version: 1.15.5
-  resolution: "@vanilla-extract/css@npm:1.15.5"
-  dependencies:
-    "@emotion/hash": ^0.9.0
-    "@vanilla-extract/private": ^1.0.6
-    css-what: ^6.1.0
-    cssesc: ^3.0.0
-    csstype: ^3.0.7
-    dedent: ^1.5.3
-    deep-object-diff: ^1.1.9
-    deepmerge: ^4.2.2
-    lru-cache: ^10.4.3
-    media-query-parser: ^2.0.2
-    modern-ahocorasick: ^1.0.0
-    picocolors: ^1.0.0
-  checksum: 0c260e55a1648a827df74cae4475a1a61767e4ef3a7a3a299853ae3f77ed220d7a4b604737886140ea9e72a379eda4ee45b7349a4651cf3d5a4f2c8697448d6d
-  languageName: node
-  linkType: hard
-
 "@vanilla-extract/css@npm:^1.14.0, @vanilla-extract/css@npm:^1.16.0":
   version: 1.17.1
   resolution: "@vanilla-extract/css@npm:1.17.1"
@@ -8735,7 +8717,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vanilla-extract/dynamic@npm:2.1.2, @vanilla-extract/dynamic@npm:^2.1.2":
+"@vanilla-extract/dynamic@npm:^2.1.2":
   version: 2.1.2
   resolution: "@vanilla-extract/dynamic@npm:2.1.2"
   dependencies:
@@ -8769,15 +8751,6 @@ __metadata:
   version: 1.0.6
   resolution: "@vanilla-extract/private@npm:1.0.6"
   checksum: 2265b02af29d8cd40f6ddeeed197fb2df1a7695f5a9821d5e3597677179be8b83bcd8fe4df4a6178544f89123d745a3c6a13599d4fe4e5873b065a8ad329f690
-  languageName: node
-  linkType: hard
-
-"@vanilla-extract/sprinkles@npm:1.6.3":
-  version: 1.6.3
-  resolution: "@vanilla-extract/sprinkles@npm:1.6.3"
-  peerDependencies:
-    "@vanilla-extract/css": ^1.0.0
-  checksum: 7eb4fe0f1a6048bf5ffb5ffab964c2d127ff95244da79dca2e448af380b591c7af3b4f63ab243584baa8a42c7694d8fe9eeb366587a2da381a481fe1a9e02af8
   languageName: node
   linkType: hard
 
@@ -10859,7 +10832,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"clsx@npm:2.1.1, clsx@npm:^2.0.0, clsx@npm:^2.1.1":
+"clsx@npm:^2.0.0, clsx@npm:^2.1.1":
   version: 2.1.1
   resolution: "clsx@npm:2.1.1"
   checksum: acd3e1ab9d8a433ecb3cc2f6a05ab95fe50b4a3cfc5ba47abb6cbf3754585fcb87b84e90c822a1f256c4198e3b41c7f6c391577ffc8678ad587fc0976b24fd57
@@ -20621,7 +20594,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qrcode@npm:1.5.4, qrcode@npm:^1.5.4":
+"qrcode@npm:^1.5.4":
   version: 1.5.4
   resolution: "qrcode@npm:1.5.4"
   dependencies:
@@ -20908,25 +20881,6 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 2c7fe9cbd766f5e54beb4bec2e2efb2de3583037b23fef8fa511ab426ed7f1ae992382db5acd8ab5bfb030a4b93a06a2ebca41377d6eeaf0e6791bb0a59616a4
-  languageName: node
-  linkType: hard
-
-"react-remove-scroll@npm:2.6.2":
-  version: 2.6.2
-  resolution: "react-remove-scroll@npm:2.6.2"
-  dependencies:
-    react-remove-scroll-bar: ^2.3.7
-    react-style-singleton: ^2.2.1
-    tslib: ^2.1.0
-    use-callback-ref: ^1.3.3
-    use-sidecar: ^1.1.2
-  peerDependencies:
-    "@types/react": "*"
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 310e6e6d2f28226a1751dc5084a2dce49167f0b69e3d78d6510f329f423ee313d4f6477f5e1adccb68baef40a7af75541e980a8c398cb82ea0d3573e514e8124
   languageName: node
   linkType: hard
 
@@ -23823,7 +23777,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ua-parser-js@npm:^1.0.37, ua-parser-js@npm:^1.0.39":
+"ua-parser-js@npm:^1.0.39":
   version: 1.0.40
   resolution: "ua-parser-js@npm:1.0.40"
   bin:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1868,30 +1868,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@coinbase/onchainkit@npm:^0.38.4":
-  version: 0.38.4
-  resolution: "@coinbase/onchainkit@npm:0.38.4"
-  dependencies:
-    "@farcaster/frame-core": ^0.0.26
-    "@farcaster/frame-sdk": ^0.0.28
-    "@farcaster/frame-wagmi-connector": ^0.0.16
-    "@tanstack/react-query": ^5
-    "@wagmi/core": ^2.16.7
-    clsx: ^2.1.1
-    graphql: ^14 || ^15 || ^16
-    graphql-request: ^6.1.0
-    qrcode: ^1.5.4
-    tailwind-merge: ^2.3.0
-    viem: ^2.23.0
-    wagmi: ^2.14.11
-  peerDependencies:
-    "@types/react": ^18 || ^19
-    react: ^18 || ^19
-    react-dom: ^18 || ^19
-  checksum: 99abe1bc50106e9b4009901607966a6084731e799484bd172ae8975333aa63171cdea556dfe91b1c7720ab00e17be7d53ad19c5e5769d1a1950f704ab72f3c10
-  languageName: node
-  linkType: hard
-
 "@coinbase/wallet-sdk-canary@npm:@coinbase/wallet-sdk@4.4.0-canary.1":
   version: 4.4.0-canary.1
   resolution: "@coinbase/wallet-sdk@npm:4.4.0-canary.1"


### PR DESCRIPTION
**What changed? Why?**
* replaced rainbowkit with walletmodal
* used `useBoolean` hook to control WalletModal visibility in FramesContext
* added raby and trust wallet to onchainkit config

![image](https://github.com/user-attachments/assets/adba525f-44a2-4e8c-a603-4ee323df27aa)


**Notes to reviewers**

**How has it been tested?**

Have you tested the following pages?

BaseWeb
- [x] base.org
- [x] base.org/names
- [x] base.org/builders
- [x] base.org/ecosystem
- [x] base.org/name/jesse
- [x] base.org/manage-names
- [x] base.org/resources

BaseDocs
- [x] docs.base.org
- [x] docs sub-pages
