### PR TITLE
chore: fix and improve `FeedbackWidget` removal regex

### DIFF
--- a/apps/base-docs/scripts/remove-feedback.ts
+++ b/apps/base-docs/scripts/remove-feedback.ts
@@ -12,10 +12,10 @@ async function removeFeedbackWidget(file: string) {
     }
 
     // Remove the import statement
-    content = content.replace(/import\s*{\s*FeedbackWidget\s*}\s*from\s*['"].*?['"]\s*\n?/g, '')
+    content = content.replace(/import\s+{[^}]*\bFeedbackWidget\b[^}]*}\s+from\s+['"][^'"]+['"];\s*\n?/g, '')
 
     // Remove the FeedbackWidget component
-    content = content.replace(/<FeedbackWidget\s*\/>\s*\n?/g, '')
+    content = content.replace(/<FeedbackWidget\b[^>]*\/>\s*\n?/g, '')
 
     // Clean up any double newlines that might have been created
     content = content.replace(/\n{3,}/g, '\n\n')


### PR DESCRIPTION
**What changed? Why?**

I updated the regular expressions used to remove `FeedbackWidget` from the code.
The previous patterns weren’t handling all edge cases, such as when there are other imports or attributes in the component.
The new regexes are more reliable and correctly remove the widget in various scenarios.

**Notes to reviewers**

The changes mainly affect how the `FeedbackWidget` is removed from both import statements and JSX components.
The new regexes ensure more robust matching and account for possible variations in the code.

**How has it been tested?**

These changes have been tested locally by running the script on several markdown and MDX files. No errors were encountered, and the widget was removed as expected.

Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources

BaseDocs
- [] docs.base.org
- [] docs sub-pages