### PR TITLE
docs: remove unnecessary `--save` flag in npm install command

### DIFF
--- a/apps/base-docs/docs/pages/cookbook/client-side-development/viem.mdx
+++ b/apps/base-docs/docs/pages/cookbook/client-side-development/viem.mdx
@@ -21,7 +21,7 @@ You can use viem to interact with smart contracts deployed on Base.
 To install viem run the following command:
 
 ```bash
-npm install --save viem
+npm install viem
 ```
 
 ## Setup


### PR DESCRIPTION
**What changed? Why?**  
The `--save` flag in `npm install` is no longer necessary since modern versions of npm save dependencies by default. Removed it to keep the command cleaner and up to date.  

**Notes to reviewers**  
This is a small cleanup to align with current npm behavior. No functional changes.  

**How has it been tested?**  
Manually verified that `npm install` without `--save` still correctly adds dependencies to `package.json`.  

Have you tested the following pages?  

**BaseWeb**  
- [ ] base.org  
- [ ] base.org/names  
- [ ] base.org/builders  
- [ ] base.org/ecosystem  
- [ ] base.org/name/jesse  
- [ ] base.org/manage-names  
- [ ] base.org/resources  

**BaseDocs**  
- [ ] docs.base.org  
- [ ] docs sub-pages  