### PR TITLE
docs: Fix Tink repository link

### DIFF
--- a/apps/base-docs/docs/pages/identity/mobile-wallet-protocol/encryption.mdx
+++ b/apps/base-docs/docs/pages/identity/mobile-wallet-protocol/encryption.mdx
@@ -116,7 +116,7 @@ However, there are two exceptions where the content data are not encrypted:
 
 Coinbase's SDK is built with 
 [Apple CryptoKit](https://developer.apple.com/documentation/cryptokit/) for iOS, 
-[Google Tink](https://github.com/google/tink) and [androidx.security](https://developer.android.com/jetpack/androidx/releases/security) for Android.
+[Google Tink](https://github.com/tink-crypto/tink) and [androidx.security](https://developer.android.com/jetpack/androidx/releases/security) for Android.
 
 ![](img/diffie-hellman.png)
 > source: https://commons.wikimedia.org/wiki/File:Public_key_shared_secret.svg


### PR DESCRIPTION
### **What changed? Why?**  
Updated the Tink repository link from `github.com/google/tink` to `github.com/tink-crypto/tink` since the project has moved. This ensures users land on the correct, actively maintained repo and avoids confusion from dead links.  

### **Notes to reviewers**  
- No functional changes—just a documentation fix.  
- Confirmed the new link resolves correctly.  

### **How has it been tested?**  
Manually verified the link redirects properly.  

**Have you tested the following pages?**  

**BaseWeb**  
- [ ] base.org  
- [ ] base.org/names  
- [ ] base.org/builders  
- [ ] base.org/ecosystem  
- [ ] base.org/name/jesse  
- [ ] base.org/manage-names  
- [ ] base.org/resources  

**BaseDocs**  
- [x] docs.base.org  
- [x] docs sub-pages  