### PR TITLE
chore: Improve isBase and isEthereum code examples

### DIFF
--- a/apps/base-docs/docs/pages/builderkits/onchainkit/config/is-base.mdx
+++ b/apps/base-docs/docs/pages/builderkits/onchainkit/config/is-base.mdx
@@ -10,16 +10,13 @@ The `isBase` utility is designed to verify if the chain id is a valid Base or Ba
 import { isBase } from '@coinbase/onchainkit';
 
 // Base Mainnet (chain ID: 8453)
-const isMainnet = isBase({ chainId: 8453 });
-console.log('Is Base Mainnet:', isMainnet); // true
+isBase({ chainId: 8453 }); // returns true
 
 // Base Sepolia (chain ID: 84532)
-const isSepolia = isBase({ chainId: 84532 });
-console.log('Is Base Sepolia:', isSepolia); // true
+isBase({ chainId: 84532 }); // returns true
 
 // Ethereum (chain ID: 1)
-const isEth = isBase({ chainId: 1 });
-console.log('Is Base:', isEth); // false
+isBase({ chainId: 1 }); // returns false
 ```
 
 ```ts [return value]

--- a/apps/base-docs/docs/pages/builderkits/onchainkit/config/is-base.mdx
+++ b/apps/base-docs/docs/pages/builderkits/onchainkit/config/is-base.mdx
@@ -9,17 +9,22 @@ The `isBase` utility is designed to verify if the chain id is a valid Base or Ba
 ```tsx twoslash [code]
 import { isBase } from '@coinbase/onchainkit';
 
-const chainId = 8453;
+// Base Mainnet (chain ID: 8453)
+const isMainnet = isBase({ chainId: 8453 });
+console.log('Is Base Mainnet:', isMainnet); // true
 
-if (isBase({ chainId })) {
-  console.log('The chainId is Base.');
-} else {
-  console.log('The chainId is not Base.');
-}
+// Base Sepolia (chain ID: 84532)
+const isSepolia = isBase({ chainId: 84532 });
+console.log('Is Base Sepolia:', isSepolia); // true
+
+// Ethereum (chain ID: 1)
+const isEth = isBase({ chainId: 1 });
+console.log('Is Base:', isEth); // false
 ```
 
 ```ts [return value]
-true;
+true; // When chainId is 8453 (Base Mainnet) or 84532 (Base Sepolia)
+false; // For all other chain IDs
 ```
 
 :::

--- a/apps/base-docs/docs/pages/builderkits/onchainkit/config/is-ethereum.mdx
+++ b/apps/base-docs/docs/pages/builderkits/onchainkit/config/is-ethereum.mdx
@@ -10,16 +10,13 @@ The `isEthereum` utility is designed to verify if the chain id is a valid Ethere
 import { isEthereum } from '@coinbase/onchainkit';
 
 // Ethereum Mainnet (chain ID: 1)
-const isMainnet = isEthereum({ chainId: 1 });
-console.log('Is Ethereum Mainnet:', isMainnet); // true
+isEthereum({ chainId: 1 }); // returns true
 
 // Ethereum Sepolia (chain ID: 11155111)
-const isSepolia = isEthereum({ chainId: 11155111 });
-console.log('Is Ethereum Sepolia:', isSepolia); // true
+isEthereum({ chainId: 11155111 }); // returns true
 
 // Base (chain ID: 8453)
-const isBase = isEthereum({ chainId: 8453 });
-console.log('Is Ethereum:', isBase); // false
+isEthereum({ chainId: 8453 }); // returns false
 ```
 
 ```ts [return value]

--- a/apps/base-docs/docs/pages/builderkits/onchainkit/config/is-ethereum.mdx
+++ b/apps/base-docs/docs/pages/builderkits/onchainkit/config/is-ethereum.mdx
@@ -9,17 +9,22 @@ The `isEthereum` utility is designed to verify if the chain id is a valid Ethere
 ```tsx twoslash [code]
 import { isEthereum } from '@coinbase/onchainkit';
 
-const chainId = 1;
+// Ethereum Mainnet (chain ID: 1)
+const isMainnet = isEthereum({ chainId: 1 });
+console.log('Is Ethereum Mainnet:', isMainnet); // true
 
-if (isEthereum({ chainId })) {
-  console.log('The chainId is Ethereum Mainnet or Ethereum Sepolia.');
-} else {
-  console.log('The chainId is not Ethereum.');
-}
+// Ethereum Sepolia (chain ID: 11155111)
+const isSepolia = isEthereum({ chainId: 11155111 });
+console.log('Is Ethereum Sepolia:', isSepolia); // true
+
+// Base (chain ID: 8453)
+const isBase = isEthereum({ chainId: 8453 });
+console.log('Is Ethereum:', isBase); // false
 ```
 
 ```ts [return value]
-true;
+true; // When chainId is 1 (Ethereum Mainnet) or 11155111 (Ethereum Sepolia)
+false; // For all other chain IDs
 ```
 
 :::

--- a/apps/base-docs/package.json
+++ b/apps/base-docs/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@coinbase/cookie-banner": "^1.0.3",
     "@coinbase/cookie-manager": "^1.1.1",
-    "@coinbase/onchainkit": "^0.38.4",
+    "@coinbase/onchainkit": "^0.38.5",
     "@coinbase/wallet-sdk-canary": "npm:@coinbase/wallet-sdk@4.4.0-canary.1",
     "@googleapis/sheets": "^5.0.5",
     "@types/react": "latest",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@coinbase/cookie-banner": "^1.0.3",
     "@coinbase/cookie-manager": "^1.1.1",
-    "@coinbase/onchainkit": "^0.38.4",
+    "@coinbase/onchainkit": "^0.38.5",
     "@datadog/browser-logs": "^5.23.3",
     "@datadog/browser-rum": "^5.23.3",
     "@frames.js/render": "^0.5.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -87,7 +87,7 @@ __metadata:
   dependencies:
     "@coinbase/cookie-banner": ^1.0.3
     "@coinbase/cookie-manager": ^1.1.1
-    "@coinbase/onchainkit": ^0.38.4
+    "@coinbase/onchainkit": ^0.38.5
     "@coinbase/wallet-sdk-canary": "npm:@coinbase/wallet-sdk@4.4.0-canary.1"
     "@googleapis/sheets": ^5.0.5
     "@types/next": ^9.0.0
@@ -124,7 +124,7 @@ __metadata:
   dependencies:
     "@coinbase/cookie-banner": ^1.0.3
     "@coinbase/cookie-manager": ^1.1.1
-    "@coinbase/onchainkit": ^0.38.4
+    "@coinbase/onchainkit": ^0.38.5
     "@datadog/browser-logs": ^5.23.3
     "@datadog/browser-rum": ^5.23.3
     "@frames.js/render": ^0.5.5
@@ -1844,11 +1844,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@coinbase/onchainkit@npm:^0.38.4":
-  version: 0.38.4
-  resolution: "@coinbase/onchainkit@npm:0.38.4"
+"@coinbase/onchainkit@npm:^0.38.5":
+  version: 0.38.5
+  resolution: "@coinbase/onchainkit@npm:0.38.5"
   dependencies:
-    "@farcaster/frame-core": ^0.0.26
     "@farcaster/frame-sdk": ^0.0.28
     "@farcaster/frame-wagmi-connector": ^0.0.16
     "@tanstack/react-query": ^5
@@ -1864,7 +1863,7 @@ __metadata:
     "@types/react": ^18 || ^19
     react: ^18 || ^19
     react-dom: ^18 || ^19
-  checksum: 99abe1bc50106e9b4009901607966a6084731e799484bd172ae8975333aa63171cdea556dfe91b1c7720ab00e17be7d53ad19c5e5769d1a1950f704ab72f3c10
+  checksum: 3adf55ba6a2576bbdea55d98c0a3575e51663a2b9888f4db69f44dff7103c014ed4b79d6f3e5dc1879ca08097ed752ef7477aceea2f7cbebfb969d50dc0c2496
   languageName: node
   linkType: hard
 
@@ -3185,7 +3184,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@farcaster/frame-core@npm:0.0.26, @farcaster/frame-core@npm:^0.0.26":
+"@farcaster/frame-core@npm:0.0.26":
   version: 0.0.26
   resolution: "@farcaster/frame-core@npm:0.0.26"
   dependencies:


### PR DESCRIPTION
**What changed? Why?**

Improve isBase and isEthereum code samples to be more clear and comprehensive. 

**Notes to reviewers**

This PR also bumps the OnchainKit version to the latest, `v0.38.5`

**How has it been tested?**
<img width="706" alt="Screenshot 2025-04-03 at 2 38 45 PM" src="https://github.com/user-attachments/assets/1f5e9965-ad87-4e4c-8d2c-1be559c01a79" />


<img width="717" alt="Screenshot 2025-04-03 at 2 38 54 PM" src="https://github.com/user-attachments/assets/9b8ae98f-48d4-4c14-9a22-7eb878d38f5d" />

Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources

BaseDocs
- [] docs.base.org
- [] docs sub-pages
