### PR TITLE
Update index.tsx

### DIFF
--- a/apps/web/src/components/base-org/shared/TopNavigation/index.tsx
+++ b/apps/web/src/components/base-org/shared/TopNavigation/index.tsx
@@ -129,7 +129,7 @@ const links: TopNavigationLink[] = [
       {
         name: 'Events',
         description: 'Connect with the Base community',
-        href: '/resources#GetInvolved',
+        href: 'https://lu.ma/base-virtualevents',
       },
       {
         name: 'Media Kit',


### PR DESCRIPTION


**What changed? Why?**
Currently `Events` is linking to GetInvolved on Base.org/resources which is not very useful. After speaking with Xen we thought this should redirect to the [Base Virtual Events Luma Page](https://lu.ma/base-virtualevents).

**Notes to reviewers**

**How has it been tested?**

Have you tested the following pages?

BaseWeb
- [x] base.org
- [] base.org/names
- [x] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [x] base.org/resources

BaseDocs
- [] docs.base.org
- [] docs sub-pages
