### PR TITLE
chore: use ioredis as kv client

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -50,6 +50,7 @@
     "ethers": "5.7.2",
     "framer-motion": "^11.9.0",
     "hls.js": "^1.5.14",
+    "ioredis": "^5.6.0",
     "ipaddr.js": "^2.2.0",
     "is-ipfs": "^8.0.4",
     "jose": "^5.4.1",

--- a/apps/web/pages/api/checkNftProof/index.ts
+++ b/apps/web/pages/api/checkNftProof/index.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { kv } from '@vercel/kv';
+import { kv } from 'apps/web/src/utils/datastores/kv';
 import { logger } from 'apps/web/src/utils/logger';
 
 type RequestBody = {

--- a/apps/web/pages/api/registry/entries.ts
+++ b/apps/web/pages/api/registry/entries.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { db } from 'apps/web/src/utils/ocsRegistry';
-import { kv } from '@vercel/kv';
+import { kv } from 'apps/web/src/utils/datastores/kv';
 import { logger } from 'apps/web/src/utils/logger';
 import { withTimeout } from 'apps/web/pages/api/decorators';
 

--- a/apps/web/pages/api/registry/featured.ts
+++ b/apps/web/pages/api/registry/featured.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { db } from 'apps/web/src/utils/ocsRegistry';
-import { kv } from '@vercel/kv';
+import { kv } from 'apps/web/src/utils/datastores/kv';
 import { logger } from 'apps/web/src/utils/logger';
 import { withTimeout } from 'apps/web/pages/api/decorators';
 

--- a/apps/web/src/utils/datastores/kv/index.ts
+++ b/apps/web/src/utils/datastores/kv/index.ts
@@ -1,0 +1,179 @@
+import Redis, { type Redis as RedisType } from 'ioredis';
+import { isDevelopment } from 'apps/web/src/constants';
+import { logger } from '../../logger';
+
+type KvConstructorParam =
+  | { url: string; tls?: boolean }
+  | { host: string; port: number; username?: string; password?: string; tls?: boolean };
+
+/**
+ * Provides a limited, type-safe interface to Redis operations.
+ * Intentionally restricts access to dangerous commands and raw client operations.
+ */
+export class KVManager {
+  private client: RedisType | null = null;
+
+  private readonly connectionArg: KvConstructorParam;
+
+  private readonly connectionTls: boolean;
+
+  constructor(connectionParam: KvConstructorParam) {
+    if (!connectionParam || (!('url' in connectionParam) && !('host' in connectionParam))) {
+      throw new Error('No URL or options provided to KVManager');
+    }
+    this.connectionArg = connectionParam;
+    this.connectionTls = connectionParam.tls ?? false;
+  }
+
+  private async getClient(): Promise<RedisType> {
+    if (!this.client) {
+      console.log(
+        'creating new redis client: ',
+        'url' in this.connectionArg ? this.connectionArg.url : this.connectionArg.host,
+      );
+      if (!this.connectionArg) {
+        throw new Error('No URL or options provided to KVManager');
+      }
+
+      try {
+        if ('url' in this.connectionArg) {
+          this.client = new Redis(this.connectionArg.url, this.connectionTls ? { tls: {} } : {});
+        } else {
+          this.client = new Redis({
+            ...this.connectionArg,
+            tls: this.connectionTls ? {} : undefined,
+          });
+        }
+
+        console.log('redis client created', this.client);
+
+        console.log(
+          `pinging ${
+            'url' in this.connectionArg ? this.connectionArg.url : this.connectionArg.host
+          }`,
+        );
+        const pingRes = await this.client.ping();
+        console.log('ping response', pingRes);
+      } catch (err) {
+        if (!isDevelopment) {
+          logger.error('KV connection failed', err);
+        }
+        console.error(err);
+        throw new Error(`Failed to connect to KV: ${err}`);
+      }
+    }
+
+    return this.client;
+  }
+
+  async ping() {
+    if (this.client) {
+      try {
+        const pingRes = await this.client.ping();
+        return pingRes;
+      } catch (err) {
+        if (!isDevelopment) {
+          logger.error('Failed to scan keys', err);
+        }
+        console.error(err);
+        throw new Error(`Failed to ping: ${err}`);
+      }
+    }
+  }
+
+  async close() {
+    if (this.client) {
+      await this.client.quit();
+      this.client = null;
+    }
+  }
+
+  async scan(cursor: number | string = '0', batchSize: number | string = 10) {
+    try {
+      const client = await this.getClient();
+      const [newCursor, elements] = batchSize
+        ? await client.scan(cursor, 'COUNT', batchSize)
+        : await client.scan(cursor);
+
+      return { cursor: newCursor, elements };
+    } catch (err) {
+      if (!isDevelopment) {
+        logger.error('Failed to scan keys', err);
+      }
+      console.error(err);
+      throw new Error(`Failed to scan keys: ${err}`);
+    }
+  }
+
+  async get<T>(key: string): Promise<T | null> {
+    try {
+      const client = await this.getClient();
+      const value = await client.get(key);
+      return value ? (JSON.parse(value) as T) : null;
+    } catch (err) {
+      if (!isDevelopment) {
+        logger.error('Failed to get key', err);
+      }
+      console.error(err);
+      throw new Error(`Failed to get key: ${err}`);
+    }
+  }
+
+  async set<T>(
+    key: string,
+    value: T,
+    options?: {
+      ex?: number;
+      nx?: boolean;
+    },
+  ) {
+    try {
+      const client = await this.getClient();
+      const stringifiedValue = JSON.stringify(value);
+
+      if (!options) {
+        return await client.set(key, stringifiedValue);
+      }
+      if (options.ex && options.nx) {
+        return await client.set(key, stringifiedValue, 'EX', options.ex, 'NX');
+      }
+      if (options.nx) {
+        return await client.set(key, stringifiedValue, 'NX');
+      }
+      if (options.ex) {
+        return await client.set(key, stringifiedValue, 'EX', options.ex);
+      }
+    } catch (err) {
+      if (!isDevelopment) {
+        logger.error('Failed to set key', err);
+      }
+      console.error(err);
+      throw new Error(`Failed to set key: ${err}`);
+    }
+  }
+
+  async incr(key: string) {
+    try {
+      const client = await this.getClient();
+      const result = await client.incr(key);
+      return result;
+    } catch (err) {
+      if (!isDevelopment) {
+        logger.error('Failed to increment key', err);
+      }
+      console.error(err);
+      throw new Error(`Failed to increment key: ${err}`);
+    }
+  }
+}
+
+function createDefaultKVManager() {
+  const url = isDevelopment ? process.env.KV_URL_DEVELOPMENT : process.env.KV_URL;
+  if (!url) {
+    throw new Error('No KV URL provided');
+  }
+  return new KVManager({ url, tls: true });
+}
+
+// Exports an instance of KVManager with the default KV URL
+export const kv = createDefaultKVManager();

--- a/apps/web/src/utils/datastores/kv/index.ts
+++ b/apps/web/src/utils/datastores/kv/index.ts
@@ -10,7 +10,7 @@ type KvConstructorParam =
  * Provides a limited, type-safe interface to Redis operations.
  * Intentionally restricts access to dangerous commands and raw client operations.
  */
-export class KVManager {
+class KVManager {
   private client: RedisType | null = null;
 
   private readonly connectionArg: KvConstructorParam;

--- a/apps/web/src/utils/proofs/sybil_resistance.ts
+++ b/apps/web/src/utils/proofs/sybil_resistance.ts
@@ -1,5 +1,5 @@
 import { getAttestations } from '@coinbase/onchainkit/identity';
-import { kv } from '@vercel/kv';
+import { kv } from 'apps/web/src/utils/datastores/kv';
 import { CoinbaseProofResponse } from 'apps/web/pages/api/proofs/coinbase';
 import RegistrarControllerABI from 'apps/web/src/abis/RegistrarControllerABI';
 import {

--- a/yarn.lock
+++ b/yarn.lock
@@ -176,6 +176,7 @@ __metadata:
     ethers: 5.7.2
     framer-motion: ^11.9.0
     hls.js: ^1.5.14
+    ioredis: ^5.6.0
     ipaddr.js: ^2.2.0
     is-ipfs: ^8.0.4
     jest: ^29.7.0
@@ -3954,6 +3955,13 @@ __metadata:
   version: 0.33.5
   resolution: "@img/sharp-win32-x64@npm:0.33.5"
   conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@ioredis/commands@npm:^1.1.1":
+  version: 1.2.0
+  resolution: "@ioredis/commands@npm:1.2.0"
+  checksum: 9b20225ba36ef3e5caf69b3c0720597c3016cc9b1e157f519ea388f621dd9037177f84cfe7e25c4c32dad7dd90c70ff9123cd411f747e053cf292193c9c461e2
   languageName: node
   linkType: hard
 
@@ -10814,6 +10822,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cluster-key-slot@npm:^1.1.0":
+  version: 1.1.2
+  resolution: "cluster-key-slot@npm:1.1.2"
+  checksum: be0ad2d262502adc998597e83f9ded1b80f827f0452127c5a37b22dfca36bab8edf393f7b25bb626006fb9fb2436106939ede6d2d6ecf4229b96a47f27edd681
+  languageName: node
+  linkType: hard
+
 "co@npm:^4.6.0":
   version: 4.6.0
   resolution: "co@npm:4.6.0"
@@ -11799,6 +11814,13 @@ __metadata:
   version: 1.0.0
   resolution: "delegates@npm:1.0.0"
   checksum: a51744d9b53c164ba9c0492471a1a2ffa0b6727451bdc89e31627fdf4adda9d51277cfcbfb20f0a6f08ccb3c436f341df3e92631a3440226d93a8971724771fd
+  languageName: node
+  linkType: hard
+
+"denque@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "denque@npm:2.1.0"
+  checksum: 1d4ae1d05e59ac3a3481e7b478293f4b4c813819342273f3d5b826c7ffa9753c520919ba264f377e09108d24ec6cf0ec0ac729a5686cbb8f32d797126c5dae74
   languageName: node
   linkType: hard
 
@@ -15469,6 +15491,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ioredis@npm:^5.6.0":
+  version: 5.6.0
+  resolution: "ioredis@npm:5.6.0"
+  dependencies:
+    "@ioredis/commands": ^1.1.1
+    cluster-key-slot: ^1.1.0
+    debug: ^4.3.4
+    denque: ^2.1.0
+    lodash.defaults: ^4.2.0
+    lodash.isarguments: ^3.1.0
+    redis-errors: ^1.2.0
+    redis-parser: ^3.0.0
+    standard-as-callback: ^2.1.0
+  checksum: b085cec251581224c6b9e3e4b0c1f92f99a272976ebcad552bc9d0c63d31abbe0208294b3acedeae4f29759ff3821478727207a47597e2ba081b1036fbc69181
+  languageName: node
+  linkType: hard
+
 "ip-address@npm:^9.0.5":
   version: 9.0.5
   resolution: "ip-address@npm:9.0.5"
@@ -17224,10 +17263,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash.defaults@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "lodash.defaults@npm:4.2.0"
+  checksum: 84923258235592c8886e29de5491946ff8c2ae5c82a7ac5cddd2e3cb697e6fbdfbbb6efcca015795c86eec2bb953a5a2ee4016e3735a3f02720428a40efbb8f1
+  languageName: node
+  linkType: hard
+
 "lodash.includes@npm:^4.3.0":
   version: 4.3.0
   resolution: "lodash.includes@npm:4.3.0"
   checksum: 71092c130515a67ab3bd928f57f6018434797c94def7f46aafa417771e455ce3a4834889f4267b17887d7f75297dfabd96231bf704fd2b8c5096dc4a913568b6
+  languageName: node
+  linkType: hard
+
+"lodash.isarguments@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "lodash.isarguments@npm:3.1.0"
+  checksum: ae1526f3eb5c61c77944b101b1f655f846ecbedcb9e6b073526eba6890dc0f13f09f72e11ffbf6540b602caee319af9ac363d6cdd6be41f4ee453436f04f13b5
   languageName: node
   linkType: hard
 
@@ -21160,6 +21213,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"redis-errors@npm:^1.0.0, redis-errors@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "redis-errors@npm:1.2.0"
+  checksum: f28ac2692113f6f9c222670735aa58aeae413464fd58ccf3fce3f700cae7262606300840c802c64f2b53f19f65993da24dc918afc277e9e33ac1ff09edb394f4
+  languageName: node
+  linkType: hard
+
+"redis-parser@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "redis-parser@npm:3.0.0"
+  dependencies:
+    redis-errors: ^1.0.0
+  checksum: 89290ae530332f2ae37577647fa18208d10308a1a6ba750b9d9a093e7398f5e5253f19855b64c98757f7129cccce958e4af2573fdc33bad41405f87f1943459a
+  languageName: node
+  linkType: hard
+
 "reflect.getprototypeof@npm:^1.0.6, reflect.getprototypeof@npm:^1.0.9":
   version: 1.0.10
   resolution: "reflect.getprototypeof@npm:1.0.10"
@@ -22467,6 +22536,13 @@ __metadata:
   dependencies:
     escape-string-regexp: ^2.0.0
   checksum: 052bf4d25bbf5f78e06c1d5e67de2e088b06871fa04107ca8d3f0e9d9263326e2942c8bedee3545795fc77d787d443a538345eef74db2f8e35db3558c6f91ff7
+  languageName: node
+  linkType: hard
+
+"standard-as-callback@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "standard-as-callback@npm:2.1.0"
+  checksum: 88bec83ee220687c72d94fd86a98d5272c91d37ec64b66d830dbc0d79b62bfa6e47f53b71646011835fc9ce7fae62739545d13124262b53be4fbb3e2ebad551c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**What changed? Why?**
What:
* implemented KV client using ioredis
* replaced @vercel/kv with ioredis for KV client
* updated all KV usage from @vercel/kv to ioredis

Why:
1. vercel is deprecating their package
2. we are migrating the datastore to CBHQ infra, which is incompatible with the vercel package

**Notes to reviewers**

**How has it been tested?**
* Tested in dev env, hitting API 1x/s to simulate prod load
![image](https://github.com/user-attachments/assets/2dac7253-d749-4216-8924-a56950868bd0)


Have you tested the following pages?

BaseWeb
- [x] base.org
- [x] base.org/names
- [x] base.org/builders
- [x] base.org/ecosystem
- [x] base.org/name/jesse
- [x] base.org/manage-names
- [x] base.org/resources

BaseDocs
- [x] docs.base.org
- [x] docs sub-pages
