### PR TITLE
chore: Update llms-full.txt links

### DIFF
--- a/apps/web/src/components/Builders/Landing/Hero/SearchModal.tsx
+++ b/apps/web/src/components/Builders/Landing/Hero/SearchModal.tsx
@@ -28,7 +28,7 @@ const searchConfig: SearchCategory[] = [
       {
         label: 'npm create onchain',
         description: (
-          <div className="px-3 pb-2 text-xs tracking-wide text-dark-palette-foregroundMuted mt-0.5">
+          <div className="mt-0.5 px-3 pb-2 text-xs tracking-wide text-dark-palette-foregroundMuted">
             Run this command in your terminal to start building with
             <Link
               href="https://docs.base.org/builderkits/onchainkit/getting-started"
@@ -57,11 +57,11 @@ const searchConfig: SearchCategory[] = [
       {
         label: 'AI docs',
         description: (
-          <div className="px-3 pb-2 text-xs tracking-wide text-dark-palette-foregroundMuted mt-0.5">
+          <div className="mt-0.5 px-3 pb-2 text-xs tracking-wide text-dark-palette-foregroundMuted">
             Use this LLM-optimized context file to accelerate your workflow with AI
           </div>
         ),
-        href: 'https://docs.base.org/llms.txt',
+        href: 'https://docs.base.org/llms-full.txt',
         icon: 'ai',
       },
     ],

--- a/apps/web/src/components/Builders/Shared/BottomCta/index.tsx
+++ b/apps/web/src/components/Builders/Shared/BottomCta/index.tsx
@@ -56,7 +56,7 @@ export function BottomCta() {
             linkClassNames="text-base font-medium text-white block"
             buttonClassNames="flex items-center justify-between px-4 pb-3 pt-3 group"
             target="_blank"
-            href="https://docs.base.org/llms.txt"
+            href="https://docs.base.org/llms-full.txt"
             eventName="bottom-cta-ai-docs"
           >
             <div className="flex items-center justify-between gap-6">


### PR DESCRIPTION
**What changed? Why?**
https://docs.base.org/llms.txt is outdated - https://docs.base.org/llms-full.txt is the new valid URL
**Notes to reviewers**

**How has it been tested?**

Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources

BaseDocs
- [] docs.base.org
- [] docs sub-pages
