### PR TITLE
feat: update startup process to use envmapper

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -20,6 +20,4 @@ EXPOSE 3000
 
 # Build at runtime so that we get ENV variables from config service and codeflow
 # This allows us to use [Automatic Static Optimization](https://nextjs.org/docs/pages/building-your-application/rendering/automatic-static-optimization)
-RUN chmod +x /repo/apps/web/scripts/startup.sh
-
 CMD ["/repo/apps/web/scripts/startup.sh"]

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -17,5 +17,9 @@ COPY . .
 RUN yarn --immutable
 
 EXPOSE 3000
-# Build at runtime so that we get ENV variables, this allows us to use [Automatic Static Optimization](https://nextjs.org/docs/pages/building-your-application/rendering/automatic-static-optimization)
-CMD ["/bin/bash", "-c", "yarn workspace @app/web next build ; yarn workspace @app/web start -p 3000"]
+
+# Build at runtime so that we get ENV variables from config service and codeflow
+# This allows us to use [Automatic Static Optimization](https://nextjs.org/docs/pages/building-your-application/rendering/automatic-static-optimization)
+RUN chmod +x /repo/apps/web/scripts/startup.sh
+
+CMD ["/repo/apps/web/scripts/startup.sh"]

--- a/apps/web/scripts/startup.sh
+++ b/apps/web/scripts/startup.sh
@@ -1,8 +1,10 @@
+#!/bin/bash
+
 # Wait for config service to map env vars
-until [ -f /var/env/config_service_env ]; do
+until [ -f /var/env/.env ]; do
   sleep 5
 done
-source /var/env/config_service_env
+source /var/env/.env
 
 # Start the application
 yarn workspace @app/web next build

--- a/apps/web/scripts/startup.sh
+++ b/apps/web/scripts/startup.sh
@@ -1,0 +1,9 @@
+# Wait for config service to map env vars
+until [ -f /var/env/config_service_env ]; do
+  sleep 5
+done
+source /var/env/config_service_env
+
+# Start the application
+yarn workspace @app/web next build
+yarn workspace @app/web start -p 3000


### PR DESCRIPTION
**What changed? Why?**
* created `startup.sh` to fetch env vars from config service
* integrated `startup.sh` into dockerfile

**Notes to reviewers**

**How has it been tested?**
* In dev env

Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources

BaseDocs
- [] docs.base.org
- [] docs sub-pages
