### PR TITLE
Smart Wallet Docs: Add patches to sidebar and serve

### DIFF
--- a/apps/base-docs/docs/public/serve.json
+++ b/apps/base-docs/docs/public/serve.json
@@ -123,7 +123,7 @@
       "destination": "/identity/smart-wallet/quickstart"
     },
     {
-      "source": "/identity/smart-wallet/",
+      "source": "/identity/smart-wallet",
       "destination": "/identity/smart-wallet/quickstart"
     },
     {

--- a/apps/base-docs/sidebar.ts
+++ b/apps/base-docs/sidebar.ts
@@ -619,7 +619,6 @@ export const sidebar: Sidebar = [
           },
           {
             text: 'Concepts',
-            link: '/identity/smart-wallet/concepts',
             items: [
               {
                 text: 'What is Smart Wallet?',
@@ -713,7 +712,6 @@ export const sidebar: Sidebar = [
           },
           {
             text: 'Guides',
-            link: '/identity/smart-wallet/guides',
             items: [
               { text: 'Sign In With Ethereum', link: '/identity/smart-wallet/guides/siwe' },
               {
@@ -743,7 +741,6 @@ export const sidebar: Sidebar = [
           },
           {
             text: 'Technical Reference',
-            link: '/identity/smart-wallet/technical-reference',
             items: [
               {
                 text: '@coinbase/wallet-sdk',

--- a/apps/base-docs/sidebar.ts
+++ b/apps/base-docs/sidebar.ts
@@ -655,7 +655,6 @@ export const sidebar: Sidebar = [
                   },
                   {
                     text: 'Optional Features',
-                    collapsed: true,
                     items: [
                       {
                         text: 'Gas-free Transactions',

--- a/apps/base-docs/sidebar.ts
+++ b/apps/base-docs/sidebar.ts
@@ -655,6 +655,7 @@ export const sidebar: Sidebar = [
                   },
                   {
                     text: 'Optional Features',
+                    collapsed: true,
                     items: [
                       {
                         text: 'Gas-free Transactions',


### PR DESCRIPTION
**What changed? Why?**

I added a few patches to Smart Wallet sidebar and redirects following the latest restructuring

BaseDocs
- [x] docs.base.org
- [x] docs sub-pages
