### PR TITLE
Expose guides in Sub Accounts Sub-section

### DIFF
--- a/apps/base-docs/sidebar.ts
+++ b/apps/base-docs/sidebar.ts
@@ -739,6 +739,24 @@ export const sidebar: Sidebar = [
               {
                 text: 'Sub Accounts',
                 link: '/identity/smart-wallet/guides/sub-accounts',
+                items: [
+                  {
+                    text: 'Project Setup',
+                    link: '/identity/smart-wallet/guides/sub-accounts/setup',
+                  },
+                  {
+                    text: 'Creating Sub Accounts',
+                    link: '/identity/smart-wallet/guides/sub-accounts/creating-sub-accounts',
+                  },
+                  {
+                    text: 'Using Sub Accounts',
+                    link: '/identity/smart-wallet/guides/sub-accounts/using-sub-accounts',
+                  },
+                  {
+                    text: 'Incorporate Spend Permissions',
+                    link: '/identity/smart-wallet/guides/sub-accounts/incorporate-spend-permissions',
+                  },
+                ],
               },
               {
                 text: 'Spend Permissions',

--- a/apps/base-docs/sidebar.ts
+++ b/apps/base-docs/sidebar.ts
@@ -700,7 +700,7 @@ export const sidebar: Sidebar = [
                   { text: 'Popups', link: '/identity/smart-wallet/concepts/usage-details/popups' },
                   {
                     text: 'Simulations',
-                    link: '/identity/smart-wallet/concepts/usage-details/Simulations',
+                    link: '/identity/smart-wallet/concepts/usage-details/simulations',
                   },
                   {
                     text: 'Gas Usage',

--- a/apps/base-docs/sidebar.ts
+++ b/apps/base-docs/sidebar.ts
@@ -738,6 +738,7 @@ export const sidebar: Sidebar = [
               },
               {
                 text: 'Sub Accounts',
+                collapsed: true,
                 link: '/identity/smart-wallet/guides/sub-accounts',
                 items: [
                   {


### PR DESCRIPTION
**What changed? Why?**
Small change to the sidebar, in order to explicitly expose guides in the Sub Accounts sub section.

BaseDocs
- [x] docs.base.org
- [x] docs sub-pages
