### PR TITLE
Add Fetch Permissions API page to Spend Permissions technical reference

### DIFF
--- a/apps/base-docs/sidebar.ts
+++ b/apps/base-docs/sidebar.ts
@@ -894,8 +894,19 @@ export const sidebar: Sidebar = [
                 ],
               },
               {
-                text: 'SpendPermissionsManager.sol',
-                link: '/identity/smart-wallet/technical-reference/spend-permissions/spendpermissionmanager',
+                text: 'Spend Permissions',
+                collapsed: true,
+                link: '/identity/smart-wallet/technical-reference/spend-permissions',
+                items: [
+                  {
+                    text: 'Smart Contract Reference',
+                    link: '/identity/smart-wallet/technical-reference/spend-permissions/spendpermissionmanager',
+                  },
+                  {
+                    text: 'Fetch Permissions API',
+                    link: '/identity/smart-wallet/technical-reference/spend-permissions/coinbase-fetchpermissions',
+                  }
+                ]
               },
               {
                 text: 'Sub Account Reference',


### PR DESCRIPTION
**What changed? Why?**

**Notes to reviewers**

**How has it been tested?**

Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources

BaseDocs
- [] docs.base.org
- [] docs sub-pages
