### PR TITLE
chore: fix theme docs

### DIFF
--- a/apps/base-docs/docs/pages/builderkits/onchainkit/guides/themes.mdx
+++ b/apps/base-docs/docs/pages/builderkits/onchainkit/guides/themes.mdx
@@ -138,64 +138,64 @@ Use CSS variables to define your custom theme.
 The class name definitions must include the `-light` or `-dark` suffix.
 
 ```css
-@layer base {
-  .custom-light {
-    /* Font and Shape */
-    --ock-font-family: 'your-custom-value';
-    --ock-border-radius: 'your-custom-value';
-    --ock-border-radius-inner: 'your-custom-value';
 
-    /* Text Colors */
-    --ock-text-inverse: 'your-custom-value';
-    --ock-text-foreground: 'your-custom-value';
-    --ock-text-foreground-muted: 'your-custom-value';
-    --ock-text-error: 'your-custom-value';
-    --ock-text-primary: 'your-custom-value';
-    --ock-text-success: 'your-custom-value';
-    --ock-text-warning: 'your-custom-value';
-    --ock-text-disabled: 'your-custom-value';
+.custom-light {
+  /* Font and Shape */
+  --ock-font-family: 'your-custom-value';
+  --ock-border-radius: 'your-custom-value';
+  --ock-border-radius-inner: 'your-custom-value';
 
-    /* Background Colors */
-    --ock-bg-default: 'your-custom-value';
-    --ock-bg-default-hover: 'your-custom-value';
-    --ock-bg-default-active: 'your-custom-value';
-    --ock-bg-alternate: 'your-custom-value';
-    --ock-bg-alternate-hover: 'your-custom-value';
-    --ock-bg-alternate-active: 'your-custom-value';
-    --ock-bg-inverse: 'your-custom-value';
-    --ock-bg-inverse-hover: 'your-custom-value';
-    --ock-bg-inverse-active: 'your-custom-value';
-    --ock-bg-primary: 'your-custom-value';
-    --ock-bg-primary-hover: 'your-custom-value';
-    --ock-bg-primary-active: 'your-custom-value';
-    --ock-bg-primary-washed: 'your-custom-value';
-    --ock-bg-primary-disabled: 'your-custom-value';
-    --ock-bg-secondary: 'your-custom-value';
-    --ock-bg-secondary-hover: 'your-custom-value';
-    --ock-bg-secondary-active: 'your-custom-value';
-    --ock-bg-error: 'your-custom-value';
-    --ock-bg-warning: 'your-custom-value';
-    --ock-bg-success: 'your-custom-value';
-    --ock-bg-default-reverse: 'your-custom-value';
+  /* Text Colors */
+  --ock-text-inverse: 'your-custom-value';
+  --ock-text-foreground: 'your-custom-value';
+  --ock-text-foreground-muted: 'your-custom-value';
+  --ock-text-error: 'your-custom-value';
+  --ock-text-primary: 'your-custom-value';
+  --ock-text-success: 'your-custom-value';
+  --ock-text-warning: 'your-custom-value';
+  --ock-text-disabled: 'your-custom-value';
 
-    /* Icon Colors */
-    --ock-icon-color-primary: 'your-custom-value';
-    --ock-icon-color-foreground: 'your-custom-value';
-    --ock-icon-color-foreground-muted: 'your-custom-value';
-    --ock-icon-color-inverse: 'your-custom-value';
-    --ock-icon-color-error: 'your-custom-value';
-    --ock-icon-color-success: 'your-custom-value';
-    --ock-icon-color-warning: 'your-custom-value';
+  /* Background Colors */
+  --ock-bg-default: 'your-custom-value';
+  --ock-bg-default-hover: 'your-custom-value';
+  --ock-bg-default-active: 'your-custom-value';
+  --ock-bg-alternate: 'your-custom-value';
+  --ock-bg-alternate-hover: 'your-custom-value';
+  --ock-bg-alternate-active: 'your-custom-value';
+  --ock-bg-inverse: 'your-custom-value';
+  --ock-bg-inverse-hover: 'your-custom-value';
+  --ock-bg-inverse-active: 'your-custom-value';
+  --ock-bg-primary: 'your-custom-value';
+  --ock-bg-primary-hover: 'your-custom-value';
+  --ock-bg-primary-active: 'your-custom-value';
+  --ock-bg-primary-washed: 'your-custom-value';
+  --ock-bg-primary-disabled: 'your-custom-value';
+  --ock-bg-secondary: 'your-custom-value';
+  --ock-bg-secondary-hover: 'your-custom-value';
+  --ock-bg-secondary-active: 'your-custom-value';
+  --ock-bg-error: 'your-custom-value';
+  --ock-bg-warning: 'your-custom-value';
+  --ock-bg-success: 'your-custom-value';
+  --ock-bg-default-reverse: 'your-custom-value';
 
-    /* Border Colors */
-    --ock-border-line-primary: 'your-custom-value';
-    --ock-border-line-default: 'your-custom-value';
-    --ock-border-line-heavy: 'your-custom-value';
-    --ock-border-line-inverse: 'your-custom-value';
-  }
+  /* Icon Colors */
+  --ock-icon-color-primary: 'your-custom-value';
+  --ock-icon-color-foreground: 'your-custom-value';
+  --ock-icon-color-foreground-muted: 'your-custom-value';
+  --ock-icon-color-inverse: 'your-custom-value';
+  --ock-icon-color-error: 'your-custom-value';
+  --ock-icon-color-success: 'your-custom-value';
+  --ock-icon-color-warning: 'your-custom-value';
 
-  .custom-dark {
-    /* Define dark mode custom classes here */
-  }
+  /* Border Colors */
+  --ock-border-line-primary: 'your-custom-value';
+  --ock-border-line-default: 'your-custom-value';
+  --ock-border-line-heavy: 'your-custom-value';
+  --ock-border-line-inverse: 'your-custom-value';
 }
+
+.custom-dark {
+  /* Define dark mode custom classes here */
+}
+
 ```


### PR DESCRIPTION
**What changed? Why?**
custom themes don't work when included in @layer base, you need to define them directly in css file

**Notes to reviewers**

**How has it been tested?**

Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources

BaseDocs
- [] docs.base.org
- [] docs sub-pages
