### PR TITLE
chore: switch to new rds infra

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -40,7 +40,6 @@
     "@types/three": "0.153.0",
     "@vercel/blob": "^0.23.4",
     "@vercel/og": "^0.6.2",
-    "@vercel/postgres-kysely": "^0.8.0",
     "base-ui": "0.1.1",
     "classnames": "^2.5.1",
     "cloudinary": "^2.5.1",

--- a/apps/web/pages/api/registry/entries.ts
+++ b/apps/web/pages/api/registry/entries.ts
@@ -1,5 +1,5 @@
 import { NextApiRequest, NextApiResponse } from 'next';
-import { vercelDb as db } from 'apps/web/src/utils/datastores/rds';
+import { db } from 'apps/web/src/utils/datastores/rds';
 import { kv } from 'apps/web/src/utils/datastores/kv';
 import { logger } from 'apps/web/src/utils/logger';
 import { withTimeout } from 'apps/web/pages/api/decorators';

--- a/apps/web/pages/api/registry/featured.ts
+++ b/apps/web/pages/api/registry/featured.ts
@@ -1,5 +1,5 @@
 import { NextApiRequest, NextApiResponse } from 'next';
-import { vercelDb as db } from 'apps/web/src/utils/datastores/rds';
+import { db } from 'apps/web/src/utils/datastores/rds';
 import { kv } from 'apps/web/src/utils/datastores/kv';
 import { logger } from 'apps/web/src/utils/logger';
 import { withTimeout } from 'apps/web/pages/api/decorators';

--- a/apps/web/src/utils/datastores/rds/index.ts
+++ b/apps/web/src/utils/datastores/rds/index.ts
@@ -1,4 +1,3 @@
-import { createKysely } from '@vercel/postgres-kysely';
 import { Kysely, PostgresDialect } from 'kysely';
 import { Pool } from 'pg';
 import { isDevelopment } from 'apps/web/src/constants';
@@ -20,4 +19,3 @@ const pool = new Pool(poolConfig);
 const dialect = new PostgresDialect({ pool });
 
 export const db = new Kysely<Database>({ dialect });
-export const vercelDb = createKysely<Database>();

--- a/apps/web/src/utils/proofs/discount_code_storage.ts
+++ b/apps/web/src/utils/proofs/discount_code_storage.ts
@@ -1,4 +1,4 @@
-import { vercelDb as db } from 'apps/web/src/utils/datastores/rds';
+import { db } from 'apps/web/src/utils/datastores/rds';
 
 const publicTableName = 'public.basenames_discount_codes';
 

--- a/apps/web/src/utils/proofs/proofs_storage.ts
+++ b/apps/web/src/utils/proofs/proofs_storage.ts
@@ -1,4 +1,4 @@
-import { vercelDb as db } from 'apps/web/src/utils/datastores/rds';
+import { db } from 'apps/web/src/utils/datastores/rds';
 import { Address } from 'viem';
 
 export enum ProofTableNamespace {

--- a/yarn.lock
+++ b/yarn.lock
@@ -162,7 +162,6 @@ __metadata:
     "@typescript-eslint/utils": ^7.8.0
     "@vercel/blob": ^0.23.4
     "@vercel/og": ^0.6.2
-    "@vercel/postgres-kysely": ^0.8.0
     autoprefixer: ^10.4.13
     base-ui: 0.1.1
     classnames: ^2.5.1
@@ -4894,15 +4893,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@neondatabase/serverless@npm:0.7.2":
-  version: 0.7.2
-  resolution: "@neondatabase/serverless@npm:0.7.2"
-  dependencies:
-    "@types/pg": 8.6.6
-  checksum: bfcd7e209aae0c0b05cbf40c5cbc105d9cf43a4f65171cee5f2a170132d015a547c5a8ee2b4cd6e963670ebe77eab5fd0db62d1636e816129fa343b1bd8ec141
-  languageName: node
-  linkType: hard
-
 "@next/bundle-analyzer@npm:^15.1.6":
   version: 15.1.7
   resolution: "@next/bundle-analyzer@npm:15.1.7"
@@ -8104,17 +8094,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/pg@npm:8.6.6":
-  version: 8.6.6
-  resolution: "@types/pg@npm:8.6.6"
-  dependencies:
-    "@types/node": "*"
-    pg-protocol: "*"
-    pg-types: ^2.2.0
-  checksum: ac145553a8ad2f357feacad1bceaf5d6ce904eb9d66233b84c469a2b4fa3738d4ebdf29b7ea45387be2d07f915fd873a229f90a2f766d7c377afa7c41fbcf8d1
-  languageName: node
-  linkType: hard
-
 "@types/pg@npm:^8.11.6":
   version: 8.11.11
   resolution: "@types/pg@npm:8.11.11"
@@ -8826,29 +8805,6 @@ __metadata:
     satori: 0.12.1
     yoga-wasm-web: 0.3.3
   checksum: 4c72cea28416fb0a93e64e61ecfb0eb639590ee465fb5a8729a684a6e4f42eabd37f73d1d7258c467231b954eac42e1039e7bae1fa5967ab223304d34656c14e
-  languageName: node
-  linkType: hard
-
-"@vercel/postgres-kysely@npm:^0.8.0":
-  version: 0.8.0
-  resolution: "@vercel/postgres-kysely@npm:0.8.0"
-  dependencies:
-    "@vercel/postgres": 0.8.0
-  peerDependencies:
-    kysely: ^0.24.2 || ^0.25.0 || ^0.26.0 || ^0.27.0
-  checksum: 3e4cb9fa2e4752c7693aefb6f15b946658d68ab38c0dcb9ae74e49f5dad22bf5a6510c4df9d78e3916115d9f1250817f5ed3361615796ec56d5181347a57abe8
-  languageName: node
-  linkType: hard
-
-"@vercel/postgres@npm:0.8.0":
-  version: 0.8.0
-  resolution: "@vercel/postgres@npm:0.8.0"
-  dependencies:
-    "@neondatabase/serverless": 0.7.2
-    bufferutil: 4.0.8
-    utf-8-validate: 6.0.3
-    ws: 8.14.2
-  checksum: c6e2683bec4df7abd0f9dfc525a62d8eab38bdc64928616b21c507445ca5574bff133ff868e7b20fe653fbca1b55341c3ab7dce6255cc05013eaa60414debd71
   languageName: node
   linkType: hard
 
@@ -10320,16 +10276,6 @@ __metadata:
     base64-js: ^1.3.1
     ieee754: ^1.2.1
   checksum: 5ad23293d9a731e4318e420025800b42bf0d264004c0286c8cc010af7a270c7a0f6522e84f54b9ad65cbd6db20b8badbfd8d2ebf4f80fa03dab093b89e68c3f9
-  languageName: node
-  linkType: hard
-
-"bufferutil@npm:4.0.8":
-  version: 4.0.8
-  resolution: "bufferutil@npm:4.0.8"
-  dependencies:
-    node-gyp: latest
-    node-gyp-build: ^4.3.0
-  checksum: 7e9a46f1867dca72fda350966eb468eca77f4d623407b0650913fadf73d5750d883147d6e5e21c56f9d3b0bdc35d5474e80a600b9f31ec781315b4d2469ef087
   languageName: node
   linkType: hard
 
@@ -19876,7 +19822,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pg-types@npm:^2.1.0, pg-types@npm:^2.2.0":
+"pg-types@npm:^2.1.0":
   version: 2.2.0
   resolution: "pg-types@npm:2.2.0"
   dependencies:
@@ -24304,16 +24250,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"utf-8-validate@npm:6.0.3":
-  version: 6.0.3
-  resolution: "utf-8-validate@npm:6.0.3"
-  dependencies:
-    node-gyp: latest
-    node-gyp-build: ^4.3.0
-  checksum: 5e21383c81ff7469c1912119ca69d07202d944c73ddd8a54b84dddcc546b939054e5101c78c294e494d206fe93bd43428adc635a0660816b3ec9c8ec89286ac4
-  languageName: node
-  linkType: hard
-
 "utf-8-validate@npm:^5.0.2":
   version: 5.0.10
   resolution: "utf-8-validate@npm:5.0.10"
@@ -25072,21 +25008,6 @@ __metadata:
     utf-8-validate:
       optional: true
   checksum: 53e991bbf928faf5dc6efac9b8eb9ab6497c69feeb94f963d648b7a3530a720b19ec2e0ec037344257e05a4f35bd9ad04d9de6f289615ffb133282031b18c61c
-  languageName: node
-  linkType: hard
-
-"ws@npm:8.14.2":
-  version: 8.14.2
-  resolution: "ws@npm:8.14.2"
-  peerDependencies:
-    bufferutil: ^4.0.1
-    utf-8-validate: ">=5.0.2"
-  peerDependenciesMeta:
-    bufferutil:
-      optional: true
-    utf-8-validate:
-      optional: true
-  checksum: 3ca0dad26e8cc6515ff392b622a1467430814c463b3368b0258e33696b1d4bed7510bc7030f7b72838b9fdeb8dbd8839cbf808367d6aae2e1d668ce741d4308b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**What changed? Why?**
* change all postgres usage to the new rds infra
* remove vercel's kysely package as it's no longer used

**Notes to reviewers**

**How has it been tested?**
* extensively in dev env (some example testing [here](https://github.cbhq.net/protocols/base-web/pull/575)).

<img width="618" alt="image" src="https://github.com/user-attachments/assets/ec9084e6-c92b-475f-adf1-bd01c4653348" />

<img width="612" alt="image" src="https://github.com/user-attachments/assets/5580bdc6-d4f1-4ed0-bf70-e70d84186bf3" />


Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources

BaseDocs
- [] docs.base.org
- [] docs sub-pages
