### PR TITLE
chore(CHAIN-1133): update out-dated contract addresses

### DIFF
--- a/apps/base-docs/docs/pages/chain/base-contracts.mdx
+++ b/apps/base-docs/docs/pages/chain/base-contracts.mdx
@@ -89,20 +89,20 @@ Certain contracts are mandatory according to the [OP Stack SDK](https://stack.op
 | Name                         | Address                                                                                                                       |
 | :--------------------------- | :---------------------------------------------------------------------------------------------------------------------------- |
 | AddressManager               | [0x709c2B8ef4A9feFc629A8a2C1AF424Dc5BD6ad1B](https://sepolia.etherscan.io/address/0x709c2B8ef4A9feFc629A8a2C1AF424Dc5BD6ad1B) |
-| AnchorStateRegistryProxy     | [0x4C8BA32A5DAC2A720bb35CeDB51D6B067D104205](https://sepolia.etherscan.io/address/0x4C8BA32A5DAC2A720bb35CeDB51D6B067D104205) |
+| AnchorStateRegistryProxy     | [0x0729957c92A1F50590A84cb2D65D761093f3f8eB](https://sepolia.etherscan.io/address/0x0729957c92A1F50590A84cb2D65D761093f3f8eB) |
 | DelayedWETHProxy (FDG)       | [0x489c2E5ebe0037bDb2DC039C5770757b8E54eA1F](https://sepolia.etherscan.io/address/0x489c2E5ebe0037bDb2DC039C5770757b8E54eA1F) |
 | DelayedWETHProxy (PDG)       | [0x27A6128F707de3d99F89Bf09c35a4e0753E1B808](https://sepolia.etherscan.io/address/0x27A6128F707de3d99F89Bf09c35a4e0753E1B808) |
 | DisputeGameFactoryProxy      | [0xd6E6dBf4F7EA0ac412fD8b65ED297e64BB7a06E1](https://sepolia.etherscan.io/address/0xd6E6dBf4F7EA0ac412fD8b65ED297e64BB7a06E1) |
-| FaultDisputeGame             | [0x861EB6dFE0FDe8c8A63E8606Fa487ee870f65E72](https://sepolia.etherscan.io/address/0x861EB6dFE0FDe8c8A63E8606Fa487ee870f65E72) |
+| FaultDisputeGame             | [0xcfce7dd673fbbbffd16ab936b7245a2f2db31c9a](https://sepolia.etherscan.io/address/0xcfce7dd673fbbbffd16ab936b7245a2f2db31c9a) |
 | L1CrossDomainMessenger       | [0xC34855F4De64F1840e5686e64278da901e261f20](https://sepolia.etherscan.io/address/0xC34855F4De64F1840e5686e64278da901e261f20) |
 | L1ERC721Bridge               | [0x21eFD066e581FA55Ef105170Cc04d74386a09190](https://sepolia.etherscan.io/address/0x21eFD066e581FA55Ef105170Cc04d74386a09190) |
 | L1StandardBridge             | [0xfd0Bf71F60660E2f608ed56e1659C450eB113120](https://sepolia.etherscan.io/address/0xfd0Bf71F60660E2f608ed56e1659C450eB113120) |
 | L2OutputOracle               | [0x84457ca9D0163FbC4bbfe4Dfbb20ba46e48DF254](https://sepolia.etherscan.io/address/0x84457ca9D0163FbC4bbfe4Dfbb20ba46e48DF254) |
-| MIPS                         | [0xaA59A0777648BC75cd10364083e878c1cCd6112a](https://sepolia.etherscan.io/address/0xaA59A0777648BC75cd10364083e878c1cCd6112a) |
+| MIPS                         | [0xF027F4A985560fb13324e943edf55ad6F1d15Dc1](https://sepolia.etherscan.io/address/0xF027F4A985560fb13324e943edf55ad6F1d15Dc1) |
 | OptimismMintableERC20Factory | [0xb1efB9650aD6d0CC1ed3Ac4a0B7f1D5732696D37](https://sepolia.etherscan.io/address/0xb1efB9650aD6d0CC1ed3Ac4a0B7f1D5732696D37) |
 | OptimismPortal               | [0x49f53e41452C74589E85cA1677426Ba426459e85](https://sepolia.etherscan.io/address/0x49f53e41452C74589E85cA1677426Ba426459e85) |
-| PermissionedDisputeGame      | [0xd53394d4f67653074aCf0B264954fe5E4F72D24f](https://sepolia.etherscan.io/address/0xd53394d4f67653074aCf0B264954fe5E4F72D24f) |
-| PreimageOracle               | [0x92240135b46fc1142dA181f550aE8f595B858854](https://sepolia.etherscan.io/address/0x92240135b46fc1142dA181f550aE8f595B858854) |
+| PermissionedDisputeGame      | [0xf0102ffe22649a5421d53acc96e309660960cf44](https://sepolia.etherscan.io/address/0xf0102ffe22649a5421d53acc96e309660960cf44) |
+| PreimageOracle               | [0x1fb8cdFc6831fc866Ed9C51aF8817Da5c287aDD3](https://sepolia.etherscan.io/address/0x1fb8cdFc6831fc866Ed9C51aF8817Da5c287aDD3) |
 | ProxyAdmin                   | [0x0389E59Aa0a41E4A413Ae70f0008e76CAA34b1F3](https://sepolia.etherscan.io/address/0x0389E59Aa0a41E4A413Ae70f0008e76CAA34b1F3) |
 | SystemConfig                 | [0xf272670eb55e895584501d564AfEB048bEd26194](https://sepolia.etherscan.io/address/0xf272670eb55e895584501d564AfEB048bEd26194) |
 
@@ -126,7 +126,7 @@ Certain contracts are mandatory according to the [OP Stack SDK](https://stack.op
 | :--------------------- | :--------------------------------------------------------------------------------------------------------------------------------- | :----------------------------------- |
 | Batch Sender           | [0x6CDEbe940BC0F26850285cacA097C11c33103E47](https://sepolia.etherscan.io/address/0x6CDEbe940BC0F26850285cacA097C11c33103E47)      | EOA managed by Coinbase Technologies |
 | Batch Inbox            | [0xff00000000000000000000000000000000084532](https://sepolia.etherscan.io/address/0xff00000000000000000000000000000000084532)      | EOA (with no known private key)      |
-| Output Proposer        | [0x20044a0d104E9e788A0C984A2B7eAe615afD046b](https://sepolia.etherscan.io/address/0x20044a0d104E9e788A0C984A2B7eAe615afD046b)      | EOA managed by Coinbase Technologies |
+| Output Proposer        | [0x037637067c1DbE6d2430616d8f54Cb774Daa5999](https://sepolia.etherscan.io/address/0x037637067c1DbE6d2430616d8f54Cb774Daa5999)      | EOA managed by Coinbase Technologies |
 | Proxy Admin Owner (L1) | [0x0fe884546476dDd290eC46318785046ef68a0BA9](https://sepolia.etherscan.io/address/0x0fe884546476dDd290eC46318785046ef68a0BA9)      | Gnosis Safe                          |
 | Challenger             | [0x8b8c52B04A38f10515C52670fcb23f3C4C44474F](https://sepolia.etherscan.io/address/0x8b8c52B04A38f10515C52670fcb23f3C4C44474F)      | EOA managed by Coinbase Technologies |
 | System config owner    | [0x0fe884546476dDd290eC46318785046ef68a0BA9](https://sepolia.etherscan.io/address/0x0fe884546476dDd290eC46318785046ef68a0BA9)      | Gnosis Safe                          |


### PR DESCRIPTION
**What changed? Why?**
We have updated contract addresses as a result of the OP Stack [Upgrade 14](https://docs.optimism.io/notices/upgrade-14) and [Upgrade 15](https://docs.optimism.io/notices/upgrade-15) for Base Sepolia.

**Notes to reviewers**

**How has it been tested?**

Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources

BaseDocs
- [] docs.base.org
- [] docs sub-pages
