### PR TITLE
docs(bridges): Fix incorrect references to Superbridge.app

### DIFF
--- a/apps/base-docs/docs/pages/chain/bridges-mainnet.mdx
+++ b/apps/base-docs/docs/pages/chain/bridges-mainnet.mdx
@@ -29,7 +29,6 @@ Brid.gg is another option that also helps you bridge ETH and supported assets be
 - [Base Mainnet](https://brid.gg/base)
 - [Base Sepolia (Testnet)](https://testnet.brid.gg/base-sepolia)
 
-
 ## Disclaimer
 
 Coinbase Technologies, Inc., provides links to these independent service providers for your
@@ -77,7 +76,7 @@ Base is committed to decentralization and the Superchain vision. Leveraging the 
 </details>
 
 <details>
-<summary>**Who operates the Superchain Bridges like Superbridge.com and Brid.gg?**</summary>
+<summary>**Who operates the Superchain Bridges like Superbridge.app and Brid.gg?**</summary>
 <br/>
 Superchain Bridges are operated by third parties, not by Coinbase Technologies, Inc. ("Coinbase"). Coinbase does not control, operate, or assume any responsibility for the performance of these external platforms. Before using any Superchain Bridge, you may be required to agree to their terms and conditions. We strongly recommend you review these terms carefully, as well as any privacy policies, to understand your rights and obligations. The integration or inclusion of the Superchain Bridges does not imply an endorsement or recommendation of any bridge by Coinbase.
 </details>

--- a/apps/base-docs/docs/public/llms-full.txt
+++ b/apps/base-docs/docs/public/llms-full.txt
@@ -2942,7 +2942,7 @@ Navigate to one of the Superchain Bridges to look up your transaction.
 
 Base is committed to decentralization and the Superchain vision. Leveraging the community to bootstrap the Superchain bridges is a step in that direction; increasing censorship resistance and decentralization.
 
-**Who operates the Superchain Bridges like Superbridge.com and Brid.gg?**
+**Who operates the Superchain Bridges like Superbridge.app and Brid.gg?**
 
 Superchain Bridges are operated by third parties, not by Coinbase Technologies, Inc. ("Coinbase"). Coinbase does not control, operate, or assume any responsibility for the performance of these external platforms. Before using any Superchain Bridge, you may be required to agree to their terms and conditions. We strongly recommend you review these terms carefully, as well as any privacy policies, to understand your rights and obligations. The integration or inclusion of the Superchain Bridges does not imply an endorsement or recommendation of any bridge by Coinbase.
 


### PR DESCRIPTION
**What changed? Why?**

Superbridge.app was erroneously referenced in FAQ as Superbridge.com

**Notes to reviewers**

**How has it been tested?**

Localhost

Have you tested the following pages?

BaseWeb
- [x] base.org
- [x] base.org/names
- [x] base.org/builders
- [x] base.org/ecosystem
- [x] base.org/name/jesse
- [x] base.org/manage-names
- [x] base.org/resources

BaseDocs
- [x] docs.base.org
- [x] docs sub-pages
