### PR TITLE
Remove deprecated chain prop from OnchainKitProvider

### DIFF
--- a/apps/base-docs/docs/components/App.tsx
+++ b/apps/base-docs/docs/components/App.tsx
@@ -57,7 +57,6 @@ export default function App({ children }: { children: ReactNode }) {
       <QueryClientProvider client={queryClient}>
         <OnchainKitProvider
           apiKey={viteCdpApiKey}
-          chain={base} // TODO: remove
           projectId={viteProjectId}
           schemaId="0xf8b05c79f090979bf4a80270aba232dff11a10d9ca55c4f88de95317970f0de9"
           config={{


### PR DESCRIPTION
This commit removes the chain prop from OnchainKitProvider as noted in the TODO comment.
The chain prop is no longer needed as the provider likely determines the chain
through other configuration options or context. This change helps clean up
unnecessary code and follows the intended implementation pattern.