### PR TITLE
fix: add error handling to rds client creation

### DIFF
--- a/apps/web/src/utils/datastores/rds/index.ts
+++ b/apps/web/src/utils/datastores/rds/index.ts
@@ -3,21 +3,48 @@ import { Kysely, PostgresDialect } from 'kysely';
 import { Pool } from 'pg';
 import { isDevelopment } from 'apps/web/src/constants';
 import { Database } from './types';
+import { logger } from 'apps/web/src/utils/logger';
 
-const poolConfig = isDevelopment
-  ? {
-      connectionString: process.env.POSTGRES_URL_DEVELOPMENT_CBHQ,
+function createDefaultRDSManager() {
+  try {
+    const poolConfig = isDevelopment
+      ? {
+          connectionString: process.env.POSTGRES_URL_DEVELOPMENT_CBHQ,
+        }
+      : {
+          connectionString: `postgresql://${process.env.RDS_USER}:${process.env.RDS_PASSWORD}@${process.env.RDS_HOST}:5432/${process.env.RDS_DB_NAME}`,
+          ssl: {
+            rejectUnauthorized: false,
+          },
+        };
+
+    const pool = new Pool(poolConfig);
+
+    const dialect = new PostgresDialect({ pool });
+
+    return new Kysely<Database>({ dialect });
+  } catch (error) {
+    if (isDevelopment) {
+      console.error('Failed to connect to RDS', error);
+    } else {
+      logger.error('Failed to connect to RDS', error);
     }
-  : {
-      connectionString: `postgresql://${process.env.RDS_USER}:${process.env.RDS_PASSWORD}@${process.env.RDS_HOST}:5432/${process.env.RDS_DB_NAME}`,
-      ssl: {
-        rejectUnauthorized: false,
-      },
-    };
+    throw new Error(`Failed to connect to RDS: ${error}`);
+  }
+}
 
-const pool = new Pool(poolConfig);
+function createVercelRDSManager() {
+  try {
+    return createKysely<Database>();
+  } catch (error) {
+    if (isDevelopment) {
+      console.error('Failed to connect to Vercel RDS', error);
+    } else {
+      logger.error('Failed to connect to Vercel Postgres', error);
+    }
+    throw new Error(`Failed to connect to Vercel Postgres: ${error}`);
+  }
+}
 
-const dialect = new PostgresDialect({ pool });
-
-export const db = new Kysely<Database>({ dialect });
-export const vercelDb = createKysely<Database>();
+export const db = createDefaultRDSManager();
+export const vercelDb = createVercelRDSManager();

--- a/apps/web/src/utils/datastores/rds/index.ts
+++ b/apps/web/src/utils/datastores/rds/index.ts
@@ -17,11 +17,8 @@ function createDefaultRDSManager() {
             rejectUnauthorized: false,
           },
         };
-
     const pool = new Pool(poolConfig);
-
     const dialect = new PostgresDialect({ pool });
-
     return new Kysely<Database>({ dialect });
   } catch (error) {
     if (isDevelopment) {
@@ -29,7 +26,7 @@ function createDefaultRDSManager() {
     } else {
       logger.error('Failed to connect to RDS', error);
     }
-    throw new Error(`Failed to connect to RDS: ${error}`);
+    return null;
   }
 }
 
@@ -42,7 +39,7 @@ function createVercelRDSManager() {
     } else {
       logger.error('Failed to connect to Vercel Postgres', error);
     }
-    throw new Error(`Failed to connect to Vercel Postgres: ${error}`);
+    return null;
   }
 }
 


### PR DESCRIPTION
**What changed? Why?**
* created utility functions with error handling for creating RDS clients
* this prevents build failures / application crashes if the RDS client is not able to be created

**Notes to reviewers**

**How has it been tested?**
locally

Have you tested the following pages?

BaseWeb
- [x] base.org
- [x] base.org/names
- [x] base.org/builders
- [x] base.org/ecosystem
- [x] base.org/name/jesse
- [x] base.org/manage-names
- [x] base.org/resources

BaseDocs
- [x] docs.base.org
- [x] docs sub-pages
