### PR TITLE
Add page for ERC-7562 AA validation rules

### DIFF
--- a/apps/base-docs/docs/pages/identity/smart-wallet/concepts/usage-details/validation-rules.mdx
+++ b/apps/base-docs/docs/pages/identity/smart-wallet/concepts/usage-details/validation-rules.mdx
@@ -1,0 +1,29 @@
+# Validation and Opcode Rules
+
+Due to the mechanics of Account Abstraction wallets, there are additional [validation rules](https://eips.ethereum.org/EIPS/eip-7562) that are applied to UserOperation transactions and enforced offchain by the bundler responsible for fronting gas associated with the UserOperation.
+These rules are designed to protect bundlers and other off-chain block builders from DoS attacks in which a bundler fronts gas for a UserOperation transaction that ultimately fails and thereby fails to reimburse the bundler.
+
+> ⚠️ Violation of these rules will result in the UserOperation being rejected by the bundler during the simulation phase.
+
+## Banned Opcodes
+
+These validation rules include a set of Opcode rules that limit the set of opcodes that can be executed by the UserOperation. Blocked opcodes include:
+
+- `ORIGIN` (`0x32`)
+- `GASPRICE` (`0x3A`)
+- `BLOCKHASH` (`0x40`)
+- `COINBASE` (`0x41`)
+- `TIMESTAMP` (`0x42`)
+- `NUMBER` (`0x43`)
+- `PREVRANDAO/DIFFICULTY` (`0x44`)
+- `GASLIMIT` (`0x45`)
+- `BASEFEE` (`0x48`)
+- `BLOBHASH` (`0x49`)
+- `BLOBBASEFEE` (`0x4A`)
+- `CREATE` (`0xF0`)
+- `INVALID` (`0xFE`)
+- `SELFDESTRUCT` (`0xFF`)
+
+> ℹ️ Note: `CREATE` is allowed in the "Contract Creation" and "Staked factory creation" sections.
+
+For the complete specification of these rules, see [EIP-7562](https://eips.ethereum.org/EIPS/eip-7562).

--- a/apps/base-docs/sidebar.ts
+++ b/apps/base-docs/sidebar.ts
@@ -726,6 +726,10 @@ export const sidebar: Sidebar = [
                     text: 'Self Calls',
                     link: '/identity/smart-wallet/concepts/usage-details/self-calls',
                   },
+                  {
+                    text: 'Validation and Opcode Rules',
+                    link: '/identity/smart-wallet/concepts/usage-details/validation-rules',
+                  },
                 ],
               },
               {


### PR DESCRIPTION
**What changed? Why?**
I've added a page under smart wallet "usage details" for ERC7562 validation rules and banned opcodes.

UserOperations submitted by bundlers must use a restricted set of opcodes and conform to other limitations due to the fact that the EOA submitting the transaction with the userOp is not the smart contract wallet address that is executing the userOp. The Bundler EOA must protect itself against operations that may pass simulation but ultimately fail onchain and thereby fail to reimburse the bundler for gas.

An onchain app that uses these banned opcodes or otherwise violates validation rules cannot be used by smart contract wallets. An app called JokeRace could not use CoinbaseSmartWallet for some but not all of their onchain execution flows. We ultimately discovered that the failing flows involved a codepath that references `tx.origin` (one of the banned opcodes).

Hopefully this documentation will help make it more clear more quickly to future devs why EVM code that relies on certain opcodes can't be used with CBSW.


**Notes to reviewers**

**How has it been tested?**
Locally

Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources

BaseDocs
- [x] docs.base.org
- [] docs sub-pages
