### PR TITLE
Fix: Correct broken Basenames OnchainKit tutorial link in FAQ

### DIFF
--- a/apps/web/src/components/Basenames/RegistrationFaq/index.tsx
+++ b/apps/web/src/components/Basenames/RegistrationFaq/index.tsx
@@ -222,7 +222,7 @@ export default function RegistrationFAQ() {
                 </a>{' '}
                 is the easiest way to get started (
                 <a
-                  href="https://docs.base.org/docs/basenames-tutorial-with-onchainkit"
+                  href="https://docs.base.org/identity/basenames/basenames-onchainkit-tutorial"
                   className="text-blue-600 hover:underline"
                 >
                   tutorial here


### PR DESCRIPTION
**What changed? Why?**

Fixed a broken link in the Basenames FAQ section on base.org/names. The "tutorial here" link in the answer to "I am a builder. How do I integrate Basenames to my app?" was pointing to a non-existent URL (https://docs.base.org/docs/basenames-tutorial-with-onchainkit) which returns a 404 error. 

This PR updates the link to the correct URL (https://docs.base.org/identity/basenames/basenames-onchainkit-tutorial) to ensure builders can easily access the proper documentation when integrating Basenames into their applications.

**Notes to reviewers**
This is a simple link correction in the FAQ component. The new link directs to the existing OnchainKit tutorial page that contains the correct integration instructions.

**How has it been tested?**
- Verified the new link resolves correctly to the intended OnchainKit tutorial documentation page
- Confirmed no other functionality is affected by this change

Have you tested the following pages?

BaseWeb
- [x] base.org/names - Verified the corrected link now works properly in the FAQ section
- [] base.org
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources

BaseDocs
- [x] docs.base.org/identity/basenames/basenames-onchainkit-tutorial - Verified this page exists and loads correctly
- [] docs sub-pages