### PR TITLE
feat: Register new basenames with base cointype fwd resolution data

### DIFF
--- a/apps/web/src/hooks/useRegisterNameCallback.ts
+++ b/apps/web/src/hooks/useRegisterNameCallback.ts
@@ -7,6 +7,7 @@ import useCapabilitiesSafe from 'apps/web/src/hooks/useCapabilitiesSafe';
 import useWriteContractsWithLogs from 'apps/web/src/hooks/useWriteContractsWithLogs';
 import useWriteContractWithReceipt from 'apps/web/src/hooks/useWriteContractWithReceipt';
 import {
+  convertChainIdToCoinTypeUint,
   formatBaseEthDomain,
   IS_EARLY_ACCESS,
   normalizeEnsDomainName,
@@ -78,6 +79,16 @@ export function useRegisterNameCallback(
       abi: L2ResolverAbi,
       functionName: 'setAddr',
       args: [namehash(formatBaseEthDomain(name, basenameChain.id)), address],
+    });
+
+    const baseCointypeData = encodeFunctionData({
+      abi: L2ResolverAbi,
+      functionName: 'setAddr',
+      args: [
+        namehash(formatBaseEthDomain(name, basenameChain.id)),
+        BigInt(convertChainIdToCoinTypeUint(basenameChain.id)),
+        address,
+      ],
     });
 
     const nameData = encodeFunctionData({

--- a/apps/web/src/hooks/useRegisterNameCallback.ts
+++ b/apps/web/src/hooks/useRegisterNameCallback.ts
@@ -105,7 +105,7 @@ export function useRegisterNameCallback(
       owner: address, // The address of the owner for the name.
       duration: secondsInYears(years), // The duration of the registration in seconds.
       resolver: USERNAME_L2_RESOLVER_ADDRESSES[basenameChain.id], // The address of the resolver to set for this name.
-      data: [addressData, nameData], //  Multicallable data bytes for setting records in the associated resolver upon registration.
+      data: [addressData, baseCointypeData, nameData], //  Multicallable data bytes for setting records in the associated resolver upon registration.
       reverseRecord, // Bool to decide whether to set this name as the "primary" name for the `owner`.
     };
 

--- a/apps/web/src/utils/usernames.ts
+++ b/apps/web/src/utils/usernames.ts
@@ -364,9 +364,9 @@ export const convertChainIdToCoinType = (chainId: number): string => {
   return cointype.toString(16).toLocaleUpperCase();
 };
 
-export const convertChainIdToCoinTypeUint = (chainId: number): number {
+export const convertChainIdToCoinTypeUint = (chainId: number): number => {
   return (0x80000000 | chainId) >>> 0;
-}
+};
 
 export const convertReverseNodeToBytes = ({
   address,

--- a/apps/web/src/utils/usernames.ts
+++ b/apps/web/src/utils/usernames.ts
@@ -360,9 +360,13 @@ export const convertChainIdToCoinType = (chainId: number): string => {
     return 'addr';
   }
 
-  const cointype = (0x80000000 | chainId) >>> 0;
+  const cointype = convertChainIdToCoinTypeUint(chainId);
   return cointype.toString(16).toLocaleUpperCase();
 };
+
+export const convertChainIdToCoinTypeUint = (chainId: number): number {
+  return (0x80000000 | chainId) >>> 0;
+}
 
 export const convertReverseNodeToBytes = ({
   address,


### PR DESCRIPTION
**What changed? Why?**

Basenames have historically been registered using the vestigial `addr` fwd resolution path. This is technically not correct since `addr` refers to the Ethereum Mainnet cointype (`60`). This PR adds the ENSIP-11 compliant forward resolution data to register new names with the Base chain id cointype `0x80002105`. 

**Notes to reviewers**

**How has it been tested?**

Registered a name on testnet and validated that we got the chainid address record set as expected: [see log 222](https://sepolia.basescan.org/tx/0x9bb2df82efe662eefc7de3c9d90ed843f7bc7458da14bd1539797f301de51a53#eventlog) 

Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources

BaseDocs
- [] docs.base.org
- [] docs sub-pages
