### PR TITLE
chore: add app name to OnchainKitProvider

### DIFF
--- a/apps/web/app/CryptoProviders.tsx
+++ b/apps/web/app/CryptoProviders.tsx
@@ -34,6 +34,7 @@ export default function CryptoProviders({
       appearance: {
         mode,
         theme,
+        name: 'Base',
       },
       wallet: {
         display: 'modal',


### PR DESCRIPTION
**What changed? Why?**

- Passed the app name (Base) to OnchainKitProvider
- Without the name, OnchainKit defaults to "Dapp", which doesn't look good in the keys.coinbase.com popup

**Notes to reviewers**

**How has it been tested?**

- Manually

| Before  | After |
| ------------- | ------------- |
| <img src="https://github.com/user-attachments/assets/029de90c-aea8-4f4d-8336-d48d8ee96494">  | <img src="https://github.com/user-attachments/assets/930dec62-7634-4328-801b-6c094613d68c"> |

Have you tested the following pages?

BaseWeb
- [x] base.org
- [x] base.org/names
- [x] base.org/builders
- [x] base.org/ecosystem
- [x] base.org/name/jesse
- [x] base.org/manage-names
- [x] base.org/resources

BaseDocs
- [x] docs.base.org
- [x] docs sub-pages
