### PR TITLE
fix: wagmi rpc

### DIFF
--- a/apps/web/app/CryptoProviders.tsx
+++ b/apps/web/app/CryptoProviders.tsx
@@ -6,6 +6,7 @@ import { useMemo } from 'react';
 import { createConfig, http, WagmiProvider } from 'wagmi';
 import { base, baseSepolia, mainnet } from 'wagmi/chains';
 import { isDevelopment } from 'apps/web/src/constants';
+import { cdpBaseRpcEndpoint, cdpBaseSepoliaRpcEndpoint } from 'apps/web/src/cdp/constants';
 
 export type CryptoProvidersProps = {
   children: React.ReactNode;
@@ -16,8 +17,8 @@ export type CryptoProvidersProps = {
 const config = createConfig({
   chains: [base, baseSepolia, mainnet],
   transports: {
-    [base.id]: http(),
-    [baseSepolia.id]: http(),
+    [base.id]: http(cdpBaseRpcEndpoint),
+    [baseSepolia.id]: http(cdpBaseSepoliaRpcEndpoint),
     [mainnet.id]: http(),
   },
   ssr: true,

--- a/apps/web/src/cdp/constants.ts
+++ b/apps/web/src/cdp/constants.ts
@@ -1,6 +1,7 @@
 export const cdpKeySecret = process.env.CDP_KEY_SECRET ?? '';
 export const cdpKeyName = process.env.CDP_KEY_NAME ?? '';
-export const cdpBaseRpcEndpoint = process.env.CDP_BASE_RPC_ENDPOINT ?? 'https://mainnet.base.org';
+export const cdpBaseRpcEndpoint =
+  process.env.NEXT_PUBLIC_CDP_BASE_RPC_ENDPOINT ?? 'https://mainnet.base.org';
 export const cdpBaseSepoliaRpcEndpoint =
-  process.env.CDP_BASE_SEPOLIA_RPC_ENDPOINT ?? 'https://sepolia.base.org';
+  process.env.NEXT_PUBLIC_CDP_BASE_SEPOLIA_RPC_ENDPOINT ?? 'https://sepolia.base.org';
 export const cdpBaseUri = process.env.CDP_BASE_URI ?? 'api.coinbase.com';


### PR DESCRIPTION
**What changed? Why?**
* Updated wagmi `createConfig` to use CDP RPC instead of the public mainnet.base.org
* Updated env var to be available client side

**Notes to reviewers**

**How has it been tested?**
* locally

previously network requests were routed to the public mainnet.base.org RPC fallback
<img width="1168" alt="image" src="https://github.com/user-attachments/assets/5773464f-86bd-4c9c-9aa4-d05c25be39aa" />

after the change, network requests are routed to the CDP RPC
 

previously the console had many errors (429s on mainnet due to rate limiting)
<img width="557" alt="image" src="https://github.com/user-attachments/assets/e74afdf1-9b9a-48e4-90fa-cc3b561e373b" />

after the change, these errors are gone


Have you tested the following pages?

BaseWeb
- [x] base.org
- [x] base.org/names
- [x] base.org/builders
- [x] base.org/ecosystem
- [x] base.org/name/jesse
- [x] base.org/manage-names
- [x] base.org/resources

BaseDocs
- [x] docs.base.org
- [x] docs sub-pages
