### PR TITLE
fix(redirect): Route tutorials to docs homepage

### DIFF
--- a/apps/base-docs/docs/public/serve.json
+++ b/apps/base-docs/docs/public/serve.json
@@ -15,6 +15,10 @@
       "destination": "/chain/network-faucets"
     },
     {
+      "source": "/tutorials/",
+      "destination": "/"
+    },
+    {
       "source": "/tutorials/deploy-with-foundry",
       "destination": "/cookbook/smart-contract-development/foundry/deploy-with-foundry"
     },


### PR DESCRIPTION
**What changed? Why?**

The /tutorials/ page has been deprecated and this routes folks hitting that URL

**Notes to reviewers**

N/A

**How has it been tested?**

Localhost

Have you tested the following pages?

BaseWeb
- [x] base.org
- [x] base.org/names
- [x] base.org/builders
- [x] base.org/ecosystem
- [x] base.org/name/jesse
- [x] base.org/manage-names
- [x] base.org/resources

BaseDocs
- [x] docs.base.org
- [x] docs sub-pages
