### PR TITLE
chore(CHAIN-1140): update out-dated contract addresses

### DIFF
--- a/apps/base-docs/docs/pages/chain/base-contracts.mdx
+++ b/apps/base-docs/docs/pages/chain/base-contracts.mdx
@@ -63,14 +63,14 @@ description: A comprehensive list of L2 contract addresses for Base Mainnet and 
 | DelayedWETHProxy (FDG)       | [0xa2f2aC6F5aF72e494A227d79Db20473Cf7A1FFE8](https://etherscan.io/address/0xa2f2aC6F5aF72e494A227d79Db20473Cf7A1FFE8) |
 | DelayedWETHProxy (PDG)       | [0x3E8a0B63f57e975c268d610ece93da5f78c01321](https://etherscan.io/address/0x3E8a0B63f57e975c268d610ece93da5f78c01321) |
 | DisputeGameFactoryProxy      | [0x43edB88C4B80fDD2AdFF2412A7BebF9dF42cB40e](https://etherscan.io/address/0x43edB88C4B80fDD2AdFF2412A7BebF9dF42cB40e) |
-| FaultDisputeGame             | [0xc5f3677c3C56DB4031ab005a3C9c98e1B79D438e](https://etherscan.io/address/0xc5f3677c3C56DB4031ab005a3C9c98e1B79D438e) |
+| FaultDisputeGame             | [0xE17d670043c3cDd705a3223B3D89A228A1f07F0f](https://etherscan.io/address/0xE17d670043c3cDd705a3223B3D89A228A1f07F0f) |
 | L1CrossDomainMessenger       | [0x866E82a600A1414e583f7F13623F1aC5d58b0Afa](https://etherscan.io/address/0x866E82a600A1414e583f7F13623F1aC5d58b0Afa) |
 | L1ERC721Bridge               | [0x608d94945A64503E642E6370Ec598e519a2C1E53](https://etherscan.io/address/0x608d94945A64503E642E6370Ec598e519a2C1E53) |
 | L1StandardBridge             | [0x3154Cf16ccdb4C6d922629664174b904d80F2C35](https://etherscan.io/address/0x3154Cf16ccdb4C6d922629664174b904d80F2C35) |
 | MIPS                         | [0x5fE03a12C1236F9C22Cb6479778DDAa4bce6299C](https://etherscan.io/address/0x5fE03a12C1236F9C22Cb6479778DDAa4bce6299C) |
 | OptimismMintableERC20Factory | [0x05cc379EBD9B30BbA19C6fA282AB29218EC61D84](https://etherscan.io/address/0x05cc379EBD9B30BbA19C6fA282AB29218EC61D84) |
 | OptimismPortal               | [0x49048044D57e1C92A77f79988d21Fa8fAF74E97e](https://etherscan.io/address/0x49048044D57e1C92A77f79988d21Fa8fAF74E97e) |
-| PermissionedDisputeGame      | [0xF62c15e2F99d4869A925B8F57076cD85335832A2](https://etherscan.io/address/0xF62c15e2F99d4869A925B8F57076cD85335832A2) |
+| PermissionedDisputeGame      | [0xE749aA49c3eDAF1DCb997eA3DAC23dff72bcb826](https://etherscan.io/address/0xE749aA49c3eDAF1DCb997eA3DAC23dff72bcb826) |
 | PreimageOracle               | [0x9c065e11870B891D214Bc2Da7EF1f9DDFA1BE277](https://etherscan.io/address/0x9c065e11870B891D214Bc2Da7EF1f9DDFA1BE277) |
 | ProxyAdmin                   | [0x0475cBCAebd9CE8AfA5025828d5b98DFb67E059E](https://etherscan.io/address/0x0475cBCAebd9CE8AfA5025828d5b98DFb67E059E) |
 | SystemConfig                 | [0x73a79Fab69143498Ed3712e519A88a918e1f4072](https://etherscan.io/address/0x73a79Fab69143498Ed3712e519A88a918e1f4072) |

--- a/apps/base-docs/docs/pages/chain/base-contracts.mdx
+++ b/apps/base-docs/docs/pages/chain/base-contracts.mdx
@@ -59,7 +59,7 @@ description: A comprehensive list of L2 contract addresses for Base Mainnet and 
 | Name                         | Address                                                                                                               |
 | :--------------------------- | :-------------------------------------------------------------------------------------------------------------------- |
 | AddressManager               | [0x8EfB6B5c4767B09Dc9AA6Af4eAA89F749522BaE2](https://etherscan.io/address/0x8EfB6B5c4767B09Dc9AA6Af4eAA89F749522BaE2) |
-| AnchorStateRegistryProxy     | [0xdB9091e48B1C42992A1213e6916184f9eBDbfEDf](https://etherscan.io/address/0xdB9091e48B1C42992A1213e6916184f9eBDbfEDf) |
+| AnchorStateRegistryProxy     | [0x496286e5eE7758de84Dd17e6d2d97afC2ACE4cc7](https://etherscan.io/address/0x496286e5eE7758de84Dd17e6d2d97afC2ACE4cc7) |
 | DelayedWETHProxy (FDG)       | [0xa2f2aC6F5aF72e494A227d79Db20473Cf7A1FFE8](https://etherscan.io/address/0xa2f2aC6F5aF72e494A227d79Db20473Cf7A1FFE8) |
 | DelayedWETHProxy (PDG)       | [0x3E8a0B63f57e975c268d610ece93da5f78c01321](https://etherscan.io/address/0x3E8a0B63f57e975c268d610ece93da5f78c01321) |
 | DisputeGameFactoryProxy      | [0x43edB88C4B80fDD2AdFF2412A7BebF9dF42cB40e](https://etherscan.io/address/0x43edB88C4B80fDD2AdFF2412A7BebF9dF42cB40e) |
@@ -67,11 +67,11 @@ description: A comprehensive list of L2 contract addresses for Base Mainnet and 
 | L1CrossDomainMessenger       | [0x866E82a600A1414e583f7F13623F1aC5d58b0Afa](https://etherscan.io/address/0x866E82a600A1414e583f7F13623F1aC5d58b0Afa) |
 | L1ERC721Bridge               | [0x608d94945A64503E642E6370Ec598e519a2C1E53](https://etherscan.io/address/0x608d94945A64503E642E6370Ec598e519a2C1E53) |
 | L1StandardBridge             | [0x3154Cf16ccdb4C6d922629664174b904d80F2C35](https://etherscan.io/address/0x3154Cf16ccdb4C6d922629664174b904d80F2C35) |
-| MIPS                         | [0x5fE03a12C1236F9C22Cb6479778DDAa4bce6299C](https://etherscan.io/address/0x5fE03a12C1236F9C22Cb6479778DDAa4bce6299C) |
+| MIPS                         | [0xF027F4A985560fb13324e943edf55ad6F1d15Dc1](https://etherscan.io/address/0xF027F4A985560fb13324e943edf55ad6F1d15Dc1) |
 | OptimismMintableERC20Factory | [0x05cc379EBD9B30BbA19C6fA282AB29218EC61D84](https://etherscan.io/address/0x05cc379EBD9B30BbA19C6fA282AB29218EC61D84) |
 | OptimismPortal               | [0x49048044D57e1C92A77f79988d21Fa8fAF74E97e](https://etherscan.io/address/0x49048044D57e1C92A77f79988d21Fa8fAF74E97e) |
 | PermissionedDisputeGame      | [0xE749aA49c3eDAF1DCb997eA3DAC23dff72bcb826](https://etherscan.io/address/0xE749aA49c3eDAF1DCb997eA3DAC23dff72bcb826) |
-| PreimageOracle               | [0x9c065e11870B891D214Bc2Da7EF1f9DDFA1BE277](https://etherscan.io/address/0x9c065e11870B891D214Bc2Da7EF1f9DDFA1BE277) |
+| PreimageOracle               | [0x1fb8cdFc6831fc866Ed9C51aF8817Da5c287aDD3](https://etherscan.io/address/0x1fb8cdFc6831fc866Ed9C51aF8817Da5c287aDD3) |
 | ProxyAdmin                   | [0x0475cBCAebd9CE8AfA5025828d5b98DFb67E059E](https://etherscan.io/address/0x0475cBCAebd9CE8AfA5025828d5b98DFb67E059E) |
 | SystemConfig                 | [0x73a79Fab69143498Ed3712e519A88a918e1f4072](https://etherscan.io/address/0x73a79Fab69143498Ed3712e519A88a918e1f4072) |
 | SystemDictator               | [0x1fE3fdd1F0193Dd657C0a9AAC37314D6B479E557](https://etherscan.io/address/0x1fE3fdd1F0193Dd657C0a9AAC37314D6B479E557) |
@@ -118,7 +118,7 @@ Certain contracts are mandatory according to the [OP Stack SDK](https://stack.op
 | Proxy Admin Owner (L1)           | [0x7bB41C3008B3f03FE483B28b8DB90e19Cf07595c](https://etherscan.io/address/0x7bB41C3008B3f03FE483B28b8DB90e19Cf07595c) | Gnosis Safe                               |
 | Challenger                       | [0x8Ca1E12404d16373Aef756179B185F27b2994F3a](https://etherscan.io/address/0x8Ca1E12404d16373Aef756179B185F27b2994F3a) | EOA managed by Coinbase Technologies      |
 | System config owner              | [0x14536667Cd30e52C0b458BaACcB9faDA7046E056](https://etherscan.io/address/0x14536667Cd30e52C0b458BaACcB9faDA7046E056) | Gnosis Safe                               |
-| Guardian                         | [0x14536667Cd30e52C0b458BaACcB9faDA7046E056](https://etherscan.io/address/0x14536667Cd30e52C0b458BaACcB9faDA7046E056) | Gnosis Safe                               |
+| Guardian                         | [0x09f7150D8c019BeF34450d6920f6B3608ceFdAf2](https://etherscan.io/address/0x09f7150D8c019BeF34450d6920f6B3608ceFdAf2) | Gnosis Safe                               |
 
 ### Base Testnet (Sepolia)
 


### PR DESCRIPTION
**What changed? Why?**
We have updated contract addresses as a result of the OP Stack [Upgrade 14](https://docs.optimism.io/notices/upgrade-14) on Base Mainnet.

**Notes to reviewers**
The [upgrade transaction](https://etherscan.io/tx/0xfd06079372fea0ef0c8907b71931fc6907cc88c39f0dc036d3ebf267686fb6da) can be used to confirm the state changes by looking at the [events](https://etherscan.io/tx/0xfd06079372fea0ef0c8907b71931fc6907cc88c39f0dc036d3ebf267686fb6da#eventlog) or [state](https://etherscan.io/tx/0xfd06079372fea0ef0c8907b71931fc6907cc88c39f0dc036d3ebf267686fb6da#statechange) sections.

**How has it been tested?**

Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources

BaseDocs
- [] docs.base.org
- [] docs sub-pages
