### PR TITLE
docs: Adds Mini Apps doc in Wallet App section

### DIFF
--- a/apps/base-docs/docs/pages/wallet-app/mini-apps.mdx
+++ b/apps/base-docs/docs/pages/wallet-app/mini-apps.mdx
@@ -12,38 +12,40 @@ If you're already using MiniKit and experiencing issues, you can refer to the [D
 
 ## Authentication
 
-As a general rule of thumb for building any mini app, we recommend that you do not automatically request that the user logs in/signs a message and instead that authentication is only used when it's needed(eg. signing up for an event, viewing authenticated resources, etc).
+As a general rule of thumb for building any mini app, we recommend that you do not automatically request that the user logs in/signs a message and instead that authentication is only used when it's needed (e.g. signing up for an event, viewing authenticated resources, etc).
 Below we will quickly cover the different methods of authentication offered for mini apps and how well each of them work in Coinbase Wallet:
 
 ### Wallet
 
 Because users in Coinbase Wallet have an in-app smart wallet that doesn't require any app switching, we recommend wallet authentication as the primary method of authentication for developers looking to create a persisted session for the mini app user.
 
-As described below we don't think it's the best practice to prompt the user to log in before that authentication will allow them to do something else in your mini app, but for cases where do you want a secure, persisted session, using a wallet connection is a great option.
+As described below, we don't think it's the best practice to prompt the user to log in before that authentication will allow them to do something else in your mini app, but for cases where do you want a secure, persisted session, using a wallet connection is a great option.
 
 ### Context Data
 
-All mini app host apps(including Coinbase Wallet) return [context data](https://miniapps.farcaster.xyz/docs/sdk/context), which tells developers about the app/mini app host the user is accessing their mini app in, as well as **which user** is interacting with their mini app.
+All mini app host apps (including Coinbase Wallet) return [context data](https://miniapps.farcaster.xyz/docs/sdk/context), which tells developers about the app/mini app host the user is accessing their mini app in, as well as **which user** is interacting with their mini app.
 
-While this data can technically be spoofed, not only can you be sure that Coinbase Wallet will always give you the accurate data as a developer but also making use of this context data is super helpful because it doesn't require any other action from the user.
+A common flow that other mini app developers follow is using the context data to either track analytics metrics or create an authentication session via a [JWT](https://jwt.io/introduction). This allows you to still track analytics/offer certain authenticated services to your users without the extra friction of signing a message or deeplinking to another app.
 
-A common flow that other mini app developers follow is using the context data to either track analytics metrics or create an authentication session via a [JWT](https://jwt.io/introduction). This allows you to still track analytics/offer authenticated services to your users without the extra friction of signing a message or deeplinking to another app.
+Something important to note is that because of how the current mini app spec is written, context data can technically be spoofed by any developer who makes their own mini app host. Because of this, we recommend that context data is not used as the **primary** method of authentication.
 
 ### Sign In with Farcaster
 
-Currently, using Sign In with Farcaster inside of Coinbase Wallet is **not recommended as the primary method of authentication**. This is because for Farcaster accounts that were created in Warpcast(which many current accounts were), using Sign In with Farcaster will require deeplinking the user to Warpcast and then back to Coinbase Wallet. While this flow still works inside of Coinbase Wallet, we recommend either wallet auth or creating an auth strategy around the context data(eg. a custom JWT with context data) for a more optimal UX.
+Currently, using Sign In with Farcaster inside of Coinbase Wallet is **not recommended as the primary method of authentication**. This is because, for Farcaster accounts that were created in Warpcast (which many current accounts were), using Sign In with Farcaster will require deeplinking the user to Warpcast and then back to Coinbase Wallet. While this flow still works inside of Coinbase Wallet, we recommend either wallet auth or creating an auth strategy around the context data (eg. a custom JWT with context data) for a more optimal UX.
 
+:::info
 Note: The Sign In with Farcaster flow will no longer require a deeplink to Warpcast when the [auth addresses FIP](https://github.com/farcasterxyz/protocol/discussions/225) lands, which will allow a set of delegated wallets to take actions on behalf of a Farcaster account's custody wallet.
+:::
 
 ## Deeplinks and SDK Actions
 
-The official mini apps SDK offers a [set of actions](https://miniapps.farcaster.xyz/docs/specification#actions)(which MiniKit offers as well) so that users of your mini app can be led to do things back in clients like Coinbase Wallet(eg. compose a cast, view a profile, etc).
+The official mini apps SDK offers a [set of actions](https://miniapps.farcaster.xyz/docs/specification#actions) (which MiniKit offers as well) so that users of your mini app can be led to do things back in clients like Coinbase Wallet (e.g. compose a cast, view a profile, etc).
 
-Although a few other mini app developers have used the workaround of inserting Warpcast-specific deeplinks in the `openUrl` function of the SDK for certain actions, **it is highly recommended that you make use of all official SDK functions instead of using Warpcast-specific deeplinks in your mini app**. This is because certain Warpcast deeplinks might lead to dead ends/unpleasent experiences, and using SDK functions instead will ensure your users have the best viewing experience possible in Coinbase Wallet.
+Although a few other mini app developers have used the workaround of inserting Warpcast-specific deeplinks in the `openUrl` function of the SDK for certain actions, **it is highly recommended that you make use of all official SDK functions instead of using Warpcast-specific deeplinks in your mini app**. This is because Warpcast-specific deeplinks might not always match Coinbase Wallet-specific deeplinks, and this could lead to a UX where the user is dead-ended from taking further action in a mini app. Using SDK functions instead will ensure your users have the best viewing experience possible in Coinbase Wallet.
 
 ## Metadata
 
-Farcaster has recently [extended the metadata spec for mini apps](https://github.com/farcasterxyz/miniapps/discussions/191), which allows developers to add screenshot links, categories, and more to their manifest(farcaster.json) file. Making use of these new metadata fields is highly recommended for increasing the chance that your mini app could be featured throughout Coinbase Wallet.
+Farcaster has recently [extended the metadata spec for mini apps](https://github.com/farcasterxyz/miniapps/discussions/191), which allows developers to add screenshot links, categories, and more to their manifest (farcaster.json) file. Making use of these new metadata fields is highly recommended for increasing the chance that your mini app could be featured throughout Coinbase Wallet.
 
 Below is a table of the new metadata fields introduced, what they mean/could potentially be used for, and an example of what a manifest file could look like with these new fields (all taken from the [official spec](https://github.com/farcasterxyz/miniapps/discussions/191))
 

--- a/apps/base-docs/docs/pages/wallet-app/mini-apps.mdx
+++ b/apps/base-docs/docs/pages/wallet-app/mini-apps.mdx
@@ -1,0 +1,102 @@
+# Mini Apps
+
+We're so excited that mini apps are coming to Coinbase Wallet! The purpose of this guide is to go over how to build or update your mini app so it works as well as possible in Coinbase Wallet.
+
+## Using MiniKit
+
+If you use MiniKit and/or follow the [MiniKit quickstart guide](/builderkits/minikit/quickstart), your mini app will work out of the box in Coinbase Wallet!
+
+For reference, MiniKit is easiest way to build mini apps on Base, allowing developers to easily build mini apps without needing to know the details of the SDK implementation. It integrates seamlessly with OnchainKit components and provides Coinbase Wallet-specific hooks.
+
+If you're already using MiniKit and experiencing issues, you can refer to the [Debugging guide](/builderkits/minikit/debugging) and if your issue isn't covered there we'd greatly appreciate if you could flag it to our team.
+
+## Authentication
+
+As a general rule of thumb for building any mini app, we recommend that you do not automatically request that the user logs in/signs a message and instead that authentication is only used when it's needed(eg. signing up for an event, viewing authenticated resources, etc).
+Below we will quickly cover the different methods of authentication offered for mini apps and how well each of them work in Coinbase Wallet:
+
+### Wallet
+
+Because users in Coinbase Wallet have an in-app smart wallet that doesn't require any app switching, we recommend wallet authentication as the primary method of authentication for developers looking to create a persisted session for the mini app user.
+
+As described below we don't think it's the best practice to prompt the user to log in before that authentication will allow them to do something else in your mini app, but for cases where do you want a secure, persisted session, using a wallet connection is a great option.
+
+### Context Data
+
+All mini app host apps(including Coinbase Wallet) return [context data](https://miniapps.farcaster.xyz/docs/sdk/context), which tells developers about the app/mini app host the user is accessing their mini app in, as well as **which user** is interacting with their mini app.
+
+While this data can technically be spoofed, not only can you be sure that Coinbase Wallet will always give you the accurate data as a developer but also making use of this context data is super helpful because it doesn't require any other action from the user.
+
+A common flow that other mini app developers follow is using the context data to either track analytics metrics or create an authentication session via a [JWT](https://jwt.io/introduction). This allows you to still track analytics/offer authenticated services to your users without the extra friction of signing a message or deeplinking to another app.
+
+### Sign In with Farcaster
+
+Currently, using Sign In with Farcaster inside of Coinbase Wallet is **not recommended as the primary method of authentication**. This is because for Farcaster accounts that were created in Warpcast(which many current accounts were), using Sign In with Farcaster will require deeplinking the user to Warpcast and then back to Coinbase Wallet. While this flow still works inside of Coinbase Wallet, we recommend either wallet auth or creating an auth strategy around the context data(eg. a custom JWT with context data) for a more optimal UX.
+
+Note: The Sign In with Farcaster flow will no longer require a deeplink to Warpcast when the [auth addresses FIP](https://github.com/farcasterxyz/protocol/discussions/225) lands, which will allow a set of delegated wallets to take actions on behalf of a Farcaster account's custody wallet.
+
+## Deeplinks and SDK Actions
+
+The official mini apps SDK offers a [set of actions](https://miniapps.farcaster.xyz/docs/specification#actions)(which MiniKit offers as well) so that users of your mini app can be led to do things back in clients like Coinbase Wallet(eg. compose a cast, view a profile, etc).
+
+Although a few other mini app developers have used the workaround of inserting Warpcast-specific deeplinks in the `openUrl` function of the SDK for certain actions, **it is highly recommended that you make use of all official SDK functions instead of using Warpcast-specific deeplinks in your mini app**. This is because certain Warpcast deeplinks might lead to dead ends/unpleasent experiences, and using SDK functions instead will ensure your users have the best viewing experience possible in Coinbase Wallet.
+
+## Metadata
+
+Farcaster has recently [extended the metadata spec for mini apps](https://github.com/farcasterxyz/miniapps/discussions/191), which allows developers to add screenshot links, categories, and more to their manifest(farcaster.json) file. Making use of these new metadata fields is highly recommended for increasing the chance that your mini app could be featured throughout Coinbase Wallet.
+
+Below is a table of the new metadata fields introduced, what they mean/could potentially be used for, and an example of what a manifest file could look like with these new fields (all taken from the [official spec](https://github.com/farcasterxyz/miniapps/discussions/191))
+
+| Experience                     | Field             | Purpose                                                | Limitations                                                                                                                                                                                                        | Design Guidelines                                                                                                                                           |
+| ------------------------------ | ----------------- | ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Mini App Store Listing**     | `iconUrl`         | Main icon                                              | 1024x1024 px PNG, no alpha                                                                                                                                                                                         | Use a bold, recognizable logo. No text. Avoid photos or screenshots.                                                                                        |
+|                                | `name`            | Display name of the app                                | 30 characters, no emojis or special characters                                                                                                                                                                     | Use brandable, unique names. Avoid generic terms. No emojis or trademark symbols.                                                                           |
+|                                | `subtitle`        | Short description under the app name                   | 30 characters, no emojis or special characters                                                                                                                                                                     | Should clarify what your app does in a catchy way. Avoid repeating the title.                                                                               |
+| **Mini App Store Page**        | `description`     | Promotional message displayed on Mini App Page         | 170 characters, no emojis or special characters                                                                                                                                                                    | Use short paragraphs, headings, and bullet points. Focus on value, not features. Include social proof if possible. Avoid jargon.                            |
+|                                | `screenshotUrls`  | Visual previews of the app, max 3 screens              | Portrait, 1284 x 2778                                                                                                                                                                                              | Focus on showing the core value or magic moment of the app in the first 2–3 shots. Use device frames and short captions.                                    |
+| **Search & Discovery**         | `primaryCategory` | Primary category of app                                | One of the pre-defined categories: `games`, `social`, `finance`, `utility`, `productivity`, `health-fitness`, `news-media`, `music`, `shopping`, `education`, `developer-tools`, `entertainment`, `art-creativity` | Games, Social, Finance, Utility, Productivity, Health & Fitness, News & Media, Music, Shopping, Education, Developer Tools, Entertainment, Art & Creativity |
+|                                | `tags`            | Descriptive tags for filtering/search                  | up to 5 tags                                                                                                                                                                                                       | Use 3–5 high-volume terms; no spaces, no repeats, no brand names. Use singular form.                                                                        |
+| **Mini App Promotional Asset** | `heroImageUrl`    | Promotional display image on top of the mini app store | 1200 x 630px (1.91:1)                                                                                                                                                                                              |                                                                                                                                                             |
+|                                | `tagline`         | Marketing tagline should be punchy and descriptive     | 30 characters                                                                                                                                                                                                      | Use for time-sensitive promos or CTAs. Keep copy active (e.g., "Grow, Raid & Rise in Stoke Fire").                                                          |
+| **Sharing Experience**         | `ogTitle`         |                                                        | 30 characters                                                                                                                                                                                                      | Use your app name + short tag (e.g., "AppName – Local News Fast"). Title case, no emojis.                                                                   |
+|                                | `ogDescription`   |                                                        | 100 characters                                                                                                                                                                                                     | Summarize core benefit in 1–2 lines. Avoid repeating OG title.                                                                                              |
+|                                | `ogImageUrl`      | Promotional image (same as app hero image)             | 1200 x 630px (1.91:1)                                                                                                                                                                                              | 1200x630 px JPG or PNG. Should show your brand clearly. No excessive text. Logo + tagline + UI is a good combo.                                             |
+
+**Example Manifest:**
+
+```
+{
+  "accountAssociation": {
+    "header": "eyJmaWQiOjkxNTIsInR5cGUiOiJjdXN0b2R5Iiwia2V5IjoiMHgwMmVmNzkwRGQ3OTkzQTM1ZkQ4NDdDMDUzRURkQUU5NDBEMDU1NTk2In0",
+    "payload": "eyJkb21haW4iOiJyZXdhcmRzLndhcnBjYXN0LmNvbSJ9",
+    "signature": "MHgxMGQwZGU4ZGYwZDUwZTdmMGIxN2YxMTU2NDI1MjRmZTY0MTUyZGU4ZGU1MWU0MThiYjU4ZjVmZmQxYjRjNDBiNGVlZTRhNDcwNmVmNjhlMzQ0ZGQ5MDBkYmQyMmNlMmVlZGY5ZGQ0N2JlNWRmNzMwYzUxNjE4OWVjZDJjY2Y0MDFj"
+  },
+  "frame": {
+    "version": "1",
+    "name": "Example Mini App",
+    "iconUrl": "https://example.com/app.png",
+    "splashImageUrl": "https://example.com/logo.png",
+    "splashBackgroundColor": "#000000",
+    "homeUrl": "https://example.com",
+    "webhookUrl": "https://example.com/api/webhook",
+    "subtitle": "Example Mini App subtitle",
+    "description": "Example Mini App subtitle",
+    "screenshotUrls": [
+      "https://example.com/screenshot1.png",
+      "https://example.com/screenshot2.png",
+      "https://example.com/screenshot3.png"
+    ],
+    "primaryCategory": "social",
+    "tags": [
+      "example",
+      "mini app",
+      "coinbase wallet"
+    ],
+    "heroImageUrl": "https://example.com/og.png",
+    "tagline": "Example Mini App tagline",
+    "ogTitle": "Example Mini App",
+    "ogDescription": "Example Mini App description",
+    "ogImageUrl": "https://example.com/og.png"
+  }
+}
+```

--- a/apps/base-docs/sidebar.ts
+++ b/apps/base-docs/sidebar.ts
@@ -611,15 +611,6 @@ export const sidebar: Sidebar = [
     ],
   },
   {
-    text: 'Wallet App',
-    items: [
-      {
-        text: 'Mini Apps',
-        link: '/wallet-app/mini-apps',
-      },
-    ],
-  },
-  {
     text: 'Blockspace Tools',
     items: [
       {
@@ -1015,6 +1006,15 @@ export const sidebar: Sidebar = [
       {
         text: 'Verifications (CDP)↗',
         link: 'https://docs.cdp.coinbase.com/verifications/docs/welcome',
+      },
+    ],
+  },
+  {
+    text: 'Wallet App',
+    items: [
+      {
+        text: 'Mini Apps',
+        link: '/wallet-app/mini-apps',
       },
     ],
   },

--- a/apps/base-docs/sidebar.ts
+++ b/apps/base-docs/sidebar.ts
@@ -611,6 +611,15 @@ export const sidebar: Sidebar = [
     ],
   },
   {
+    text: 'Wallet App',
+    items: [
+      {
+        text: 'Mini Apps',
+        link: '/wallet-app/mini-apps',
+      },
+    ],
+  },
+  {
     text: 'Blockspace Tools',
     items: [
       {


### PR DESCRIPTION
**What changed? Why?**
This PR adds a new root-level section called "Wallet App" and a doc/guide in that section called "Mini Apps" that goes over best practices for building mini apps.

**Notes to reviewers**

**How has it been tested?**
I tested both the dev server and build locally, and I also tested the changes on a demo Vercel build

Have you tested the following pages?

BaseWeb
- [x] base.org
- [x] base.org/names
- [x] base.org/builders
- [x] base.org/ecosystem
- [x] base.org/name/jesse
- [x] base.org/manage-names
- [x] base.org/resources

BaseDocs
- [x] docs.base.org
- [x] docs sub-pages
