### PR TITLE
docs: fix typos in MiniKit quickstart guide

### DIFF
--- a/apps/base-docs/docs/pages/builderkits/minikit/quickstart.mdx
+++ b/apps/base-docs/docs/pages/builderkits/minikit/quickstart.mdx
@@ -1,6 +1,6 @@
 # MiniKit Quickstart
 
-This guide shows you how to get started with MiniKit, the easist way to build mini apps on Base! It can also be used to update an exisitng standalone app to a mini app. We'll start by setting up the template project with the CLI tool and then explore both built-in and additional features of MiniKit.
+This guide shows you how to get started with MiniKit, the easiest way to build mini apps on Base! It can also be used to update an existing standalone app to a mini app. We'll start by setting up the template project with the CLI tool and then explore both built-in and additional features of MiniKit.
 
 ## Prerequisites
 


### PR DESCRIPTION
**What changed? Why?**
Fixed two typos in the MiniKit quickstart guide documentation:
1. Changed "easist" to "easiest" in the introduction paragraph
2. Changed "exisitng" to "existing" in the same sentence

These typos were making the documentation less professional and potentially confusing for developers following the guide.

**Notes to reviewers**
Simple documentation typo fixes that improve readability and professionalism of the guides.

**How has it been tested?**
Verified that the text now reads correctly with proper spelling.

Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources

BaseDocs
- [x] docs.base.org/builderkits/minikit/quickstart - Verified the fixed typos
- [] docs sub-pages