### PR TITLE
Fix/documentation typos

### DIFF
--- a/apps/base-docs/docs/pages/builderkits/minikit/overview.mdx
+++ b/apps/base-docs/docs/pages/builderkits/minikit/overview.mdx
@@ -9,7 +9,7 @@ description: Easiest way to build Mini Apps on Base
   src="/images/minikit/minikit-cli.gif"
   height="364"/>
 
-MiniKit is easiest way to build Mini Apps on Base, allowing developers to easily build applications without needing to know the details of the SDK implementation. It integrates seamlessly with OnchainKit components and provides Coinbase Wallet-specific hooks.
+MiniKit is the easiest way to build Mini Apps on Base, allowing developers to easily build applications without needing to know the details of the SDK implementation. It integrates seamlessly with OnchainKit components and provides Coinbase Wallet-specific hooks.
 
 ## Why MiniKit?
 

--- a/apps/base-docs/docs/pages/builderkits/minikit/quickstart.mdx
+++ b/apps/base-docs/docs/pages/builderkits/minikit/quickstart.mdx
@@ -110,7 +110,7 @@ The template comes with several pre-implemented features. Let's explore where th
 
 ### MiniKitProvider
 
-The `MiniKitProvider` is set up in your `providers.tsx` file. It wraps your application to handle initialization, events, and automatically applie client safeAreaInsets to ensure your app doesn't overlap parent application elements.
+The `MiniKitProvider` is set up in your `providers.tsx` file. It wraps your application to handle initialization, events, and automatically applies client safeAreaInsets to ensure your app doesn't overlap parent application elements.
 
 ```tsx [app/providers.tsx]
 import { MiniKitProvider } from '@coinbase/onchainkit/minikit';
@@ -135,7 +135,7 @@ export function Providers(props: { children: ReactNode }) {
 }
 ```
 
-The MiniKitProvider also sets up your wagmi and react-query providers automatically, elimintaing that initial setup work.
+The MiniKitProvider also sets up your wagmi and react-query providers automatically, eliminating that initial setup work.
 
 ### useMiniKit
 
@@ -170,7 +170,7 @@ Enter `y` to proceed with the setup and your browser will open to the following 
   height="364"
 />
 
-The wallet that you connect must be your Farcaster custody wallet. You can import this wallet to your prefered wallet using the recovery phrase. You can find your recovery phrase in the Warpcast app under Settings -> Advanced -> Farcster recovery phrase.
+The wallet that you connect must be your Farcaster custody wallet. You can import this wallet to your prefered wallet using the recovery phrase. You can find your recovery phrase in the Warpcast app under Settings -> Advanced -> Farcaster recovery phrase.
 
 Once connected, add the vercel url and sign the manifest. This will automatically update your .env variables locally, but we'll need to update Vercel's .env variables.
 
@@ -229,7 +229,7 @@ const openUrl = useOpenUrl()
 </footer>
 ```
 
-Now that we've reviewed the MiniKit teamplate and the functionality already implemented, lets add some additional MiniKit features.
+Now that we've reviewed the MiniKit template and the functionality already implemented, lets add some additional MiniKit features.
 
 ## Additional MiniKit Features
 
@@ -280,7 +280,7 @@ usePrimaryButton(
 )
 ```
 
-You'll notice that adding the Primary button takes up space at the bottom of the frame, which causes the "BUILT ON BASE WITH MINIKIT" button to move upwards and overlap with the contorls.
+You'll notice that adding the Primary button takes up space at the bottom of the frame, which causes the "BUILT ON BASE WITH MINIKIT" button to move upwards and overlap with the controls.
 We can quickly fix that by changing the text to "BUILT WITH MINIKIT" and removing the `ml-4` style in the `className` of the `<button>`
 
 ### `useViewProfile`
@@ -310,7 +310,7 @@ const handleViewProfile = () => {
 
 ### `useNotification`
 
-One of the major benefits of mini apps is that you can send notifications to your users through their socail app.
+One of the major benefits of mini apps is that you can send notifications to your users through their social app.
 
 Recall the token and url we saved in the [useAddFrame section](docs.base.org/builderkits/minikit/quickstart#useaddframe)? We'll use those now to send a user a notification. In this guide, we'll simply send a test notification unrelated to the game activity.
 

--- a/apps/base-docs/docs/pages/builderkits/minikit/quickstart.mdx
+++ b/apps/base-docs/docs/pages/builderkits/minikit/quickstart.mdx
@@ -1,6 +1,6 @@
 # MiniKit Quickstart
 
-This guide shows you how to get started with MiniKit, the easist way to build mini apps on Base! It can also be used to update an exisitng standalone app to a mini app. We'll start by setting up the template project with the CLI tool and then explore both built-in and additional features of MiniKit.
+This guide shows you how to get started with MiniKit, the easiest way to build mini apps on Base! It can also be used to update an existing standalone app to a mini app. We'll start by setting up the template project with the CLI tool and then explore both built-in and additional features of MiniKit.
 
 ## Prerequisites
 

--- a/apps/base-docs/docs/pages/identity/basenames/basenames-onchainkit-tutorial.mdx
+++ b/apps/base-docs/docs/pages/identity/basenames/basenames-onchainkit-tutorial.mdx
@@ -89,19 +89,18 @@ declare module 'wagmi' {
 
 This configuration sets up the wagmi project to connect to the Base and BaseSepolia networks, utilizing Coinbase Wallet and other connectors.
 
-Now we’ll create a component to display the Basenames associated with an address.
+Now we'll create a component to display the Basenames associated with an address.
 
 :::tip[Use Base as your chain]
-Ensure Chain is Set to Base Be sure to set the `chain={base}` parameter; otherwise, it will default to ENS (Ethereum Name Service).
+Ensure Chain is Set to Base. Be sure to set the `chain={base}` parameter; otherwise, it will default to ENS (Ethereum Name Service).
 :::
 
 ```typescript filename="src/components/basename.tsx"
 'use client';
 import React from 'react';
-('use client');
-import React from 'react';
 import { Avatar, Identity, Name, Address } from '@coinbase/onchainkit/identity';
 import { base } from 'viem/chains';
 
 interface DisplayBasenameProps {
-  address: `0x${string}`
+  address: `0x${string}`;
+}


### PR DESCRIPTION
**What changed? Why?**
Fixed typos and formatting issues in documentation files to improve readability and professionalism:

1. In **MiniKit overview.mdx**:
   - Added missing "the" in "MiniKit is the easiest way"

2. In **MiniKit quickstart.mdx**:
   - Fixed various typos:
     - "easist" → "easiest" 
     - "exisitng" → "existing"
     - "applie" → "applies" 
     - "elimintaing" → "eliminating"
     - "Farcster" → "Farcaster"
     - "teamplate" → "template"
     - "contorls" → "controls"
     - "socail" → "social"

3. In **Basenames tutorial**:
   - Added period for better readability in the tip section
   - Fixed duplicate import statements syntax
   - Added missing semicolon and closing brace to interface definition

These fixes make the documentation more professional and easier to follow, improving the developer experience when implementing MiniKit and Basenames features.

**Notes to reviewers**
These are simple typo and syntax fixes that maintain the original meaning of the text while improving readability.

**How has it been tested?**
I've verified that the markdown renders correctly with the changes and that the syntax in code examples is valid.

Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources

BaseDocs
- [x] docs.base.org/builderkits/minikit/overview - Verified fix for "the easiest way"
- [x] docs.base.org/builderkits/minikit/quickstart - Verified all typo fixes
- [x] docs.base.org/identity/basenames/basenames-onchainkit-tutorial - Verified syntax and formatting fixes
- [] docs sub-pages
