### PR TITLE
Quick fix to a link in Sub Accounts guide

### DIFF
--- a/apps/base-docs/docs/pages/identity/smart-wallet/guides/sub-accounts/index.mdx
+++ b/apps/base-docs/docs/pages/identity/smart-wallet/guides/sub-accounts/index.mdx
@@ -31,7 +31,7 @@ In this guide, we'll set up a basic React app using NextJS and Wagmi that:
 
 If you want to skip ahead and just get the final code, you can find it here:
 
-<GithubRepoCard title="Sub Account Starter Template Demo" githubUrl="https://github.com/base/demos/smart-wallet/sub-accounts-demo" />
+<GithubRepoCard title="Sub Account Starter Template Demo" githubUrl="https://github.com/base/demos/tree/master/smart-wallet/sub-accounts-demo" />
 
 ## Guide Sections
 

--- a/apps/base-docs/docs/pages/identity/smart-wallet/guides/sub-accounts/using-sub-accounts.mdx
+++ b/apps/base-docs/docs/pages/identity/smart-wallet/guides/sub-accounts/using-sub-accounts.mdx
@@ -31,7 +31,7 @@ By the end of this guide, you will:
 
 If you want to skip ahead and just get the final code, you can find it here:
 
-<GithubRepoCard title="Sub Account Starter Template Demo" githubUrl="https://github.com/base/demos/smart-wallet/sub-accounts-demo" />
+<GithubRepoCard title="Sub Account Starter Template Demo" githubUrl="https://github.com/base/demos/tree/master/smart-wallet/sub-accounts-demo" />
 
 ## Sign a Message
 


### PR DESCRIPTION
**What changed? Why?**

Little patch to fix the wrong linking

BaseDocs
- [x] docs.base.org
- [x] docs sub-pages
