### PR TITLE
docs(sc): Add link to blog announcement post

### DIFF
--- a/apps/base-docs/docs/pages/chain/security-council.mdx
+++ b/apps/base-docs/docs/pages/chain/security-council.mdx
@@ -21,7 +21,7 @@ upholds key [Neutrality Principles](https://www.coinbase.com/blog/coinbases-neut
 
 As part of our ongoing commitment to decentralization, Base launched
 [permissionless fault proofs](https://base.mirror.xyz/eOsedW4tm8MU5OhdGK107A9wsn-aU7MAb8f3edgX5Tk) in
-October 2024, decentralized control of contract upgrades via a Security Council
+October 2024, [decentralized control of contract upgrades](https://base.mirror.xyz/tWDMlGp48fF0MeADcLQruUBq1Qxkou4O5x3ax8Rm3jA) via a Security Council
 in April 2025, and has now reached Stage 1 Decentralization.
 
 In reaching **Stage 1**, Base provides stronger security guarantees and fewer

--- a/apps/base-docs/docs/pages/chain/security-council.mdx
+++ b/apps/base-docs/docs/pages/chain/security-council.mdx
@@ -51,7 +51,7 @@ satisfies all requirements.
 **Member Selection criteria**
 
 - Representation across diverse geographic regions and international territories
-- Strong alignment with Base’s mission and values
+- Strong alignment with [Base’s mission and values](https://base.mirror.xyz/jjQnUq_UNTQOk7psnGBFOsShi7FlrRp8xevQUipG_Gk)
 - Diverse organizations - each member represents a separate entity
 - Proven track record in the Base and Ethereum ecosystem - in good standing in upholding professional and ethical standards in the community
 - Technical competency and good security practices - has completed screening processes, including background checks, and have shown ability to securely store and use sensitive key materials
@@ -62,34 +62,34 @@ This is a living list that will stay up to date with membership. As of April 202
 
 - [Entity] Aerodrome – signer based in Japan
   - [Aerodrome](https://aerodrome.finance/) is a decentralized exchange on Base where users can swap, earn rewards and actively participate in the onchain economy.
-  - 0xa5959a39cA67b9fb473E4A3A898C611EEAc9CB73
+  - `0xa5959a39cA67b9fb473E4A3A898C611EEAc9CB73`
 - [Entity] Moonwell – signer based in Brazil
   - [Moonwell](https://moonwell.fi/) is a decentralized lending and borrowing platform built on Base.
-  - 0x21C7D1e6A81Daca071bA94839ab74C39A25f851F
+  - `0x21C7D1e6A81Daca071bA94839ab74C39A25f851F`
 - [Entity] Blackbird – signer based in USA
   - [Blackbird](https://www.blackbird.xyz/) is a loyalty and payments platform built specifically for the restaurant industry, powered by Base.
-  - 0xA5657B88A0130a626fcDd6aAA59522373438CdFE
+  - `0xA5657B88A0130a626fcDd6aAA59522373438CdFE`
 - [Entity] ChainSafe – signer based in Canada
   - [ChainSafe](https://chainsafe.io/) is a blockchain R&D firm focused on decentralized infrastructure.
-  - 0x1C56A6d2A6Af643cea4E62e72B75B9bDe8d62e2B
+  - `0x1C56A6d2A6Af643cea4E62e72B75B9bDe8d62e2B`
 - [Entity] Talent Protocol – signer based in Portugal
   - [Talent Protocol](https://app.talentprotocol.com/) brings professional reputation onchain to help Base builders showcase their skills and get the recognition they deserve.
-  - 0x5ff5C78ff194acc24C22DAaDdE4D639ebF18ACC6
+  - `0x5ff5C78ff194acc24C22DAaDdE4D639ebF18ACC6`
 - [Entity] Moshicam – signer based in USA
   - [Moshicam](https://moshi.cam/) is a community-based photo editing app built on Base.
-  - 0xa8ee754FD1d069fb4B5d652730A0ca5e07a3fb06
+  - `0xa8ee754FD1d069fb4B5d652730A0ca5e07a3fb06`
 - [Individual] Seneca – based in USA
   - Seneca is the co-founder of [Rounds](https://rounds.wtf/), a social platform which has [powered](https://x.com/jessepollak/status/1781069700652523725) grant distribution to Base builders.
-  - 0x82C80F34C4b5c153dB76122a11AaD2F77C99E766
+  - `0x82C80F34C4b5c153dB76122a11AaD2F77C99E766`
 - [Individual] Juan Suarez – based in USA
   - Juan is an active member of the Base ecosystem and has advised a number of key Base projects. He is a former member of the Coinbase Legal Team.
-  - 0x99DB5BbA0db16e9aD05e3ff53310683CC3C971D2
+  - `0x99DB5BbA0db16e9aD05e3ff53310683CC3C971D2`
 - [Individual] Toady Hawk – based in Canada
   - [Toady Hawk](https://warpcast.com/toadyhawk.eth) is the founder of [Zero Rights Media](https://warpcast.com/zerorightsmedia), an open source onchain media org on Base (producers of ZEROPOD), and [The Yellow Collective](https://warpcast.com/basedandyellow), an onchain culture club for artists and creators on Base.
-  - 0x0E8A99738a50D523871739c6d676554b0E34252f
+  - `0x0E8A99738a50D523871739c6d676554b0E34252f`
 - [Individual] Roberto Bayardo – based in USA
   - [Roberto Bayardo](https://warpcast.com/bayardo.eth) is an engineer at Commonware, building a framework for high-performance blockchains. He is a former core Base contributor.
-  - 0x18e982274f8C5B548D5aAc7aBef44D61504e1b3E
+  - `0x18e982274f8C5B548D5aAc7aBef44D61504e1b3E`
 
 Individuals representing each entity are not published to protect personal privacy and to enhance security.
 


### PR DESCRIPTION
**What changed? Why?**

docs(sc): Add link to blog announcement post

**Notes to reviewers**

N/A

**How has it been tested?**

Localhost

Have you tested the following pages?

BaseWeb
- [x] base.org
- [x] base.org/names
- [x] base.org/builders
- [x] base.org/ecosystem
- [x] base.org/name/jesse
- [x] base.org/manage-names
- [x] base.org/resources

BaseDocs
- [x] docs.base.org
- [x] docs sub-pages
