### PR TITLE
fix: dynamic route params

### DIFF
--- a/apps/web/app/(basenames)/api/basenames/metadata/[tokenId]/route.ts
+++ b/apps/web/app/(basenames)/api/basenames/metadata/[tokenId]/route.ts
@@ -24,8 +24,6 @@ export async function GET(
   const { tokenId } = await params;
   const formattedTokenId = tokenId.replace(/\.json$/, '');
 
-  console.log({ searchParams: request.nextUrl, tokenId: formattedTokenId });
-
   if (!formattedTokenId) {
     return NextResponse.json({ error: '400: tokenId is missing' }, { status: 400 });
   }

--- a/apps/web/app/(basenames)/api/basenames/talentprotocol/[address]/route.ts
+++ b/apps/web/app/(basenames)/api/basenames/talentprotocol/[address]/route.ts
@@ -1,8 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { logger } from 'apps/web/src/utils/logger';
 
-export async function GET(request: NextRequest) {
-  const address = request.nextUrl.searchParams.get('address');
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ address: string }> },
+) {
+  const { address } = await params;
 
   if (!address || typeof address !== 'string') {
     return NextResponse.json({ error: '400: address is required' }, { status: 400 });

--- a/apps/web/app/(basenames)/api/name/[alreadyClaimedName]/route.ts
+++ b/apps/web/app/(basenames)/api/name/[alreadyClaimedName]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { queryCbGpt } from 'apps/web/src/cdp/api/cb-gpt';
 import { logger } from 'apps/web/src/utils/logger';
-import { withTimeout } from 'apps/web/app/api/decorators';
+import { withTimeoutWithParams } from 'apps/web/app/api/decorators';
 
 export type NameSuggestionResponseData = {
   suggestion: string[];
@@ -37,8 +37,11 @@ Focus on quality and creativity in your suggestions.`;
 const chatLlm = 'claude-3-5-sonnet@20240620';
 const ownershipRegistryComponentId = process.env.OWNERSHIP_REGISTRY_COMPONENT_ID ?? '';
 
-async function handler(request: NextRequest) {
-  const alreadyClaimedName = request.nextUrl.searchParams.get('alreadyClaimedName');
+async function handler(
+  request: NextRequest,
+  { params }: { params: Promise<{ alreadyClaimedName: string }> },
+) {
+  const { alreadyClaimedName } = await params;
   if (!alreadyClaimedName || typeof alreadyClaimedName !== 'string') {
     return NextResponse.json<ApiResponse>(
       { error: '400: name is required and must be a string' },
@@ -79,4 +82,4 @@ async function handler(request: NextRequest) {
   }
 }
 
-export const GET = withTimeout(handler);
+export const GET = withTimeoutWithParams<{ alreadyClaimedName: string }>(handler);

--- a/apps/web/app/api/decorators.ts
+++ b/apps/web/app/api/decorators.ts
@@ -3,6 +3,11 @@ import { NextRequest, NextResponse } from 'next/server';
 
 type NextApiHandler = (req: NextRequest) => Promise<NextResponse>;
 
+type NextApiHandlerWithParams<T = Record<string, string>> = (
+  req: NextRequest,
+  params: { params: Promise<T> },
+) => Promise<NextResponse>;
+
 const defaultTimeout = process.env.DEFAULT_API_TIMEOUT ?? 5000;
 export function withTimeout(
   handler: NextApiHandler,
@@ -15,6 +20,42 @@ export function withTimeout(
 
     const handlerPromise = new Promise<NextResponse>((resolve, reject) => {
       Promise.resolve(handler(req))
+        .then((response) => resolve(response))
+        .catch((error) => reject(error));
+    });
+
+    try {
+      return await Promise.race([handlerPromise, timeoutPromise]);
+    } catch (error) {
+      if (error instanceof Error) {
+        if (error.message === 'Request timed out') {
+          logger.error('Request timed out', error, {
+            endpoint_url: req.url,
+            params: req.nextUrl.searchParams,
+          });
+          return NextResponse.json({ error: 'Request timed out' }, { status: 408 });
+        }
+      }
+      logger.error('Error in withTimeout', error, {
+        endpoint_url: req.url,
+        params: req.nextUrl.searchParams,
+      });
+      return NextResponse.json({ error: 'Something went wrong' }, { status: 500 });
+    }
+  };
+}
+
+export function withTimeoutWithParams<T>(
+  handler: NextApiHandlerWithParams<T>,
+  timeoutLimit = defaultTimeout,
+): NextApiHandlerWithParams<T> {
+  return async (req, params) => {
+    const timeoutPromise = new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error('Request timed out')), timeoutLimit as number),
+    );
+
+    const handlerPromise = new Promise<NextResponse>((resolve, reject) => {
+      Promise.resolve(handler(req, params))
         .then((response) => resolve(response))
         .catch((error) => reject(error));
     });


### PR DESCRIPTION
**What changed? Why?**
* updated api routes with dynamic route segments to pull `params` using [dynamic params](https://nextjs.org/docs/app/building-your-application/routing/dynamic-routes) instead of searchParams
* created decorator `withTimeoutWithParams` to handle routes that have dynamic route segments

**Notes to reviewers**

**How has it been tested?**
* locally, vercel preview
<img width="1498" alt="image" src="https://github.com/user-attachments/assets/7d542a8e-ef4c-44f6-9992-3745fa210f8d" />


Have you tested the following pages?

BaseWeb
- [x] base.org
- [x] base.org/names
- [x] base.org/builders
- [x] base.org/ecosystem
- [x] base.org/name/jesse
- [x] base.org/manage-names
- [x] base.org/resources

BaseDocs
- [] docs.base.org
- [] docs sub-pages
