### PR TITLE
fix link to display image hardhat-verify-sbs.mdx

### DIFF
--- a/apps/base-docs/docs/pages/learn/hardhat-verify/hardhat-verify-sbs.mdx
+++ b/apps/base-docs/docs/pages/learn/hardhat-verify/hardhat-verify-sbs.mdx
@@ -28,7 +28,7 @@ The way smart contracts are verified is by simply uploading the source code and 
 
 Once the contract is verified, the Etherscan explorer shows a status like the following image:
 
-![Verified contract](/images/learn/hardhat-verify/hardhat-verify.png)
+![Verified contract](https://github.com/base/web/blob/master/apps/base-docs/docs/public/images/learn/hardhat-verify/hardhat-verify.png)
 
 Luckily, Hardhat and Hardhat-deploy already contain a built-in capability to do this task easily on your behalf.
 
@@ -44,7 +44,7 @@ In order to obtain an Etherscan API key, visit [Etherscan](https://etherscan.io/
 
 Then, go to [https://etherscan.io/myapikey](https://etherscan.io/myapikey) and create an API key by clicking the **Add** button:
 
-![Add key](/images/learn/hardhat-verify/harhat-verify-create-key.png)
+![Add key](https://github.com/base/web/blob/master/apps/base-docs/docs/public/images/learn/hardhat-verify/harhat-verify-create-key.png)
 
 Bear in mind that different networks have other Blockchain explorers. For example:
 


### PR DESCRIPTION
**What changed? Why?**
<img width="277" alt="image" src="https://github.com/user-attachments/assets/2cd1ede3-1dfe-4934-8b55-6af8ace45e77" />
_________
<img width="243" alt="image" src="https://github.com/user-attachments/assets/4b8f66fb-fe84-49ac-93bf-b68c5360b616" />

fixed , thanks 