### PR TITLE
chore(redirect): Set up vanity link pointing to Luma

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -296,6 +296,11 @@ module.exports = extendBaseConfig(
           permanent: false,
         },
         {
+          source: '/luma',
+          destination: 'https://lu.ma/base-virtualevents',
+          permanent: true,
+        },
+        {
           source: '/registry',
           destination: 'https://buildonbase.deform.cc/getstarted/',
           permanent: true,


### PR DESCRIPTION
**What changed? Why?**

This creates a vanity URL to point to our virtual events page on Luma, by request of the Base Global Builders team

**Notes to reviewers**

N/A

**How has it been tested?**

Localhost

Have you tested the following pages?

BaseWeb
- [x] base.org
- [x] base.org/names
- [x] base.org/builders
- [x] base.org/ecosystem
- [x] base.org/name/jesse
- [x] base.org/manage-names
- [x] base.org/resources

BaseDocs
- [x] docs.base.org
- [x] docs sub-pages
