### PR TITLE
docs: fix filename typo in lib/spender.ts

### DIFF
--- a/apps/base-docs/docs/pages/identity/smart-wallet/guides/spend-permissions.mdx
+++ b/apps/base-docs/docs/pages/identity/smart-wallet/guides/spend-permissions.mdx
@@ -61,7 +61,7 @@ Our client is what our app will use to communicate with the blockchain.
 
 Create a sibling directory to `app` called `lib` and add the following `spender.ts` file to create your spender client.
 
-```ts [lib/spender. ts]
+```ts [lib/spender.ts]
 import { createPublicClient, createWalletClient, Hex, http } from "viem";
 import { baseSepolia } from "viem/chains";
 import { privateKeyToAccount } from "viem/accounts";


### PR DESCRIPTION
**What changed? Why?**

<img width="576" alt="Снимок экрана 2025-05-01 в 21 02 14" src="https://github.com/user-attachments/assets/5831d166-6846-41e2-b167-f8bf3396f983" />

saw there was an extra space in the filename (`spender. ts` instead of `spender.ts`), just cleaned it up so things don’t break 😅  


**Notes to reviewers**

**How has it been tested?**

Have you tested the following pages?

BaseWeb
- [x] base.org
- [x] base.org/names
- [x] base.org/builders
- [x] base.org/ecosystem
- [x] base.org/name/jesse
- [x] base.org/manage-names
- [x] base.org/resources

BaseDocs
- [x] docs.base.org
- [x] docs sub-pages
