### PR TITLE
docs: Fix verb agreement in "Developer settings" description

### DIFF
--- a/apps/base-docs/docs/pages/identity/wallet-sdk/developer-settings.mdx
+++ b/apps/base-docs/docs/pages/identity/wallet-sdk/developer-settings.mdx
@@ -4,7 +4,7 @@ sidebar_label: 'Developer Settings'
 slug: 'developer-settings'
 ---
 
-Developer settings provides additional features for development and managing your wallet, such as enabling test networks, viewing your private key, and other experimental features.
+Developer settings provide additional features for development and managing your wallet, such as enabling test networks, viewing your private key, and other experimental features.
 
 ![new-developer-settings.gif](/images/wallet-sdk/developer-settings-overview.gif)
 


### PR DESCRIPTION
**What changed? Why?**  
Fixed a grammar issue in the phrase "Developer settings provides...". Since "Developer settings" is plural, it should be "provide". This improves clarity and correctness in the UI text.

**Notes to reviewers**  
Just a small wording correction — no functional changes.

**How has it been tested?**  
Checked the updated text in the UI to confirm it displays correctly.

Have you tested the following pages?

BaseWeb  
- [x] base.org  
- [ ] base.org/names  
- [ ] base.org/builders  
- [ ] base.org/ecosystem  
- [ ] base.org/name/jesse  
- [ ] base.org/manage-names  
- [ ] base.org/resources  

BaseDocs  
- [x] docs.base.org  
- [ ] docs sub-pages  