### PR TITLE
Fix typos and formatting issues in MiniKit quickstart documentation

### DIFF
--- a/apps/base-docs/docs/pages/builderkits/minikit/quickstart.mdx
+++ b/apps/base-docs/docs/pages/builderkits/minikit/quickstart.mdx
@@ -28,7 +28,7 @@ npx create-onchain --mini
 
 ## When prompted, enter your CDP Client API key.
 
-You can get a CDP API key by going to the (CDP Portal)[portal.cdp.coinbase.com] and navigating API Keys -> Client API Key.
+You can get a CDP API key by going to the [CDP Portal](portal.cdp.coinbase.com) and navigating API Keys -> Client API Key.
 
 ## Skip Frames Account Manifest Setup
 
@@ -140,7 +140,7 @@ export function Providers(props: { children: ReactNode }) {
 }
 ```
 
-The MiniKitProvider also sets up your wagmi and react-query providers automatically, elimintaing that initial setup work.
+The MiniKitProvider also sets up your wagmi and react-query providers automatically, eliminating that initial setup work.
 
 ### useMiniKit
 
@@ -175,7 +175,7 @@ Enter `y` to proceed with the setup and your browser will open to the following 
   height="364"
 />
 
-The wallet that you connect must be your Farcaster custody wallet. You can import this wallet to your prefered wallet using the recovery phrase. You can find your recovery phrase in the Warpcast app under Settings -> Advanced -> Farcster recovery phrase.
+The wallet that you connect must be your Farcaster custody wallet. You can import this wallet to your prefered wallet using the recovery phrase. You can find your recovery phrase in the Warpcast app under Settings -> Advanced -> Farcaster recovery phrase.
 
 Once connected, add the vercel url and sign the manifest. This will automatically update your .env variables locally, but we'll need to update Vercel's .env variables.
 
@@ -256,7 +256,7 @@ const close = useClose()
   {saveFrameButton}
   <button
     type="button"
-    className="cursor-pointer bg-transparent font-semibold text-sm pl-2""
+    className="cursor-pointer bg-transparent font-semibold text-sm pl-2"
     onClick={close}
     >
     CLOSE
@@ -270,7 +270,7 @@ If you reload the frame in the Warpcast dev tools preview, you'll now see the cl
 
 The Primary Button is a button that always exists at the bottom of the frame. Its good for managing global state which is relevant throughout your mini app.
 
-For the template example, we'll use the Priamry Button to Pause and Restart the game. The game state is managed within the `snake.tsx` component, and we can easily add the `usePrimaryButton` hook there since the MiniKit hooks are available throughout the app.
+For the template example, we'll use the Primary Button to Pause and Restart the game. The game state is managed within the `snake.tsx` component, and we can easily add the `usePrimaryButton` hook there since the MiniKit hooks are available throughout the app.
 
 ```tsx [/app/components/snake.tsx]
 // add an import for usePrimaryButton
@@ -315,7 +315,7 @@ const handleViewProfile = () => {
 
 ### `useNotification`
 
-One of the major benefits of mini apps is that you can send notifications to your users through their socail app.
+One of the major benefits of mini apps is that you can send notifications to your users through their social app.
 
 Recall the token and url we saved in the [useAddFrame section](docs.base.org/builderkits/minikit/quickstart#useaddframe)? We'll use those now to send a user a notification. In this guide, we'll simply send a test notification unrelated to the game activity.
 


### PR DESCRIPTION
**What changed? Why?**
This PR addresses several typos and formatting issues in the MiniKit quickstart documentation:

- Fixed link formatting for CDP Portal
- Corrected spelling of `eliminating` (was `elimintaing`)
- Fixed spelling of `Primary` (was `Priamry`)
- Corrected spelling of `social` (was `socail`)
- Removed extra quotation mark in className attribute
- Fixed spelling of `Farcaster` (was `Farcster`)

These changes improve readability and maintain consistency throughout the documentation.
*
