### PR TITLE
fix: Add base.org and *.base.org to img-src CSP

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -133,6 +133,8 @@ const contentSecurityPolicy = {
     "'self'",
     'blob:',
     'data:',
+    'https://base.org',
+    'https://*.base.org',
     'https://euc.li',
     'https://*.walletconnect.com/', // WalletConnect
     'https://i.seadn.io/', // ens avatars


### PR DESCRIPTION
**What changed? Why?**

- Added base.org and *.base.org to img-src CSP to fix connect modal image not loading
- Did not touch other directives because CSP is fragile and figured a targeted fix would be better
- Fun fact: 'self' doesn't cover different subdomains

<img width="544" alt="Screenshot 2025-05-05 at 8 52 59 PM" src="https://github.com/user-attachments/assets/6448d81f-8d7a-432b-ab7a-f6b4f39d42c4" />

**Notes to reviewers**

- n/a

**How has it been tested?**

- Manually

Have you tested the following pages?

BaseWeb
- [x] base.org
- [x] base.org/names
- [x] base.org/builders
- [x] base.org/ecosystem
- [x] base.org/name/jesse
- [x] base.org/manage-names
- [x] base.org/resources

BaseDocs
- [x] docs.base.org
- [x] docs sub-pages
