### PR TITLE
Remove profiles from sidebar

### DIFF
--- a/apps/base-docs/sidebar.ts
+++ b/apps/base-docs/sidebar.ts
@@ -713,10 +713,6 @@ export const sidebar: Sidebar = [
                         text: 'Sub Accounts',
                         link: '/identity/smart-wallet/concepts/features/optional/sub-accounts',
                       },
-                      {
-                        text: 'Profiles',
-                        link: '/identity/smart-wallet/concepts/features/optional/profiles',
-                      },
                     ],
                   },
                 ],
@@ -787,10 +783,6 @@ export const sidebar: Sidebar = [
                 text: 'Spend Permissions',
                 collapsed: true,
                 link: '/identity/smart-wallet/guides/spend-permissions',
-              },
-              {
-                text: 'Profiles',
-                link: '/identity/smart-wallet/guides/profiles',
               },
             ],
           },


### PR DESCRIPTION
**What changed? Why?**
Removing Profiles from Sidebar

BaseDocs
- [x] docs.base.org
- [x] docs sub-pages
