### PR TITLE
Fix/sidebar foundry links

### DIFF
--- a/apps/base-docs/docs/pages/builderkits/minikit/overview.mdx
+++ b/apps/base-docs/docs/pages/builderkits/minikit/overview.mdx
@@ -9,7 +9,7 @@ description: Easiest way to build Mini Apps on Base
   src="/images/minikit/minikit-cli.gif"
   height="364"/>
 
-MiniKit is easiest way to build Mini Apps on Base, allowing developers to easily build applications without needing to know the details of the SDK implementation. It integrates seamlessly with OnchainKit components and provides Coinbase Wallet-specific hooks.
+MiniKit is the easiest way to build Mini Apps on Base, allowing developers to easily build applications without needing to know the details of the SDK implementation. It integrates seamlessly with OnchainKit components and provides Coinbase Wallet-specific hooks.
 
 ## Why MiniKit?
 

--- a/apps/base-docs/docs/pages/builderkits/minikit/quickstart.mdx
+++ b/apps/base-docs/docs/pages/builderkits/minikit/quickstart.mdx
@@ -110,7 +110,7 @@ The template comes with several pre-implemented features. Let's explore where th
 
 ### MiniKitProvider
 
-The `MiniKitProvider` is set up in your `providers.tsx` file. It wraps your application to handle initialization, events, and automatically applie client safeAreaInsets to ensure your app doesn't overlap parent application elements.
+The `MiniKitProvider` is set up in your `providers.tsx` file. It wraps your application to handle initialization, events, and automatically applies client safeAreaInsets to ensure your app doesn't overlap parent application elements.
 
 ```tsx [app/providers.tsx]
 import { MiniKitProvider } from '@coinbase/onchainkit/minikit';
@@ -135,7 +135,7 @@ export function Providers(props: { children: ReactNode }) {
 }
 ```
 
-The MiniKitProvider also sets up your wagmi and react-query providers automatically, elimintaing that initial setup work.
+The MiniKitProvider also sets up your wagmi and react-query providers automatically, eliminating that initial setup work.
 
 ### useMiniKit
 
@@ -170,7 +170,7 @@ Enter `y` to proceed with the setup and your browser will open to the following 
   height="364"
 />
 
-The wallet that you connect must be your Farcaster custody wallet. You can import this wallet to your prefered wallet using the recovery phrase. You can find your recovery phrase in the Warpcast app under Settings -> Advanced -> Farcster recovery phrase.
+The wallet that you connect must be your Farcaster custody wallet. You can import this wallet to your prefered wallet using the recovery phrase. You can find your recovery phrase in the Warpcast app under Settings -> Advanced -> Farcaster recovery phrase.
 
 Once connected, add the vercel url and sign the manifest. This will automatically update your .env variables locally, but we'll need to update Vercel's .env variables.
 
@@ -229,7 +229,7 @@ const openUrl = useOpenUrl()
 </footer>
 ```
 
-Now that we've reviewed the MiniKit teamplate and the functionality already implemented, lets add some additional MiniKit features.
+Now that we've reviewed the MiniKit template and the functionality already implemented, lets add some additional MiniKit features.
 
 ## Additional MiniKit Features
 
@@ -280,7 +280,7 @@ usePrimaryButton(
 )
 ```
 
-You'll notice that adding the Primary button takes up space at the bottom of the frame, which causes the "BUILT ON BASE WITH MINIKIT" button to move upwards and overlap with the contorls.
+You'll notice that adding the Primary button takes up space at the bottom of the frame, which causes the "BUILT ON BASE WITH MINIKIT" button to move upwards and overlap with the controls.
 We can quickly fix that by changing the text to "BUILT WITH MINIKIT" and removing the `ml-4` style in the `className` of the `<button>`
 
 ### `useViewProfile`
@@ -310,7 +310,7 @@ const handleViewProfile = () => {
 
 ### `useNotification`
 
-One of the major benefits of mini apps is that you can send notifications to your users through their socail app.
+One of the major benefits of mini apps is that you can send notifications to your users through their social app.
 
 Recall the token and url we saved in the [useAddFrame section](docs.base.org/builderkits/minikit/quickstart#useaddframe)? We'll use those now to send a user a notification. In this guide, we'll simply send a test notification unrelated to the game activity.
 

--- a/apps/base-docs/docs/pages/builderkits/minikit/quickstart.mdx
+++ b/apps/base-docs/docs/pages/builderkits/minikit/quickstart.mdx
@@ -1,6 +1,6 @@
 # MiniKit Quickstart
 
-This guide shows you how to get started with MiniKit, the easist way to build mini apps on Base! It can also be used to update an exisitng standalone app to a mini app. We'll start by setting up the template project with the CLI tool and then explore both built-in and additional features of MiniKit.
+This guide shows you how to get started with MiniKit, the easiest way to build mini apps on Base! It can also be used to update an existing standalone app to a mini app. We'll start by setting up the template project with the CLI tool and then explore both built-in and additional features of MiniKit.
 
 ## Prerequisites
 

--- a/apps/base-docs/docs/pages/identity/basenames/basenames-onchainkit-tutorial.mdx
+++ b/apps/base-docs/docs/pages/identity/basenames/basenames-onchainkit-tutorial.mdx
@@ -89,19 +89,18 @@ declare module 'wagmi' {
 
 This configuration sets up the wagmi project to connect to the Base and BaseSepolia networks, utilizing Coinbase Wallet and other connectors.
 
-Now we’ll create a component to display the Basenames associated with an address.
+Now we'll create a component to display the Basenames associated with an address.
 
 :::tip[Use Base as your chain]
-Ensure Chain is Set to Base Be sure to set the `chain={base}` parameter; otherwise, it will default to ENS (Ethereum Name Service).
+Ensure Chain is Set to Base. Be sure to set the `chain={base}` parameter; otherwise, it will default to ENS (Ethereum Name Service).
 :::
 
 ```typescript filename="src/components/basename.tsx"
 'use client';
 import React from 'react';
-('use client');
-import React from 'react';
 import { Avatar, Identity, Name, Address } from '@coinbase/onchainkit/identity';
 import { base } from 'viem/chains';
 
 interface DisplayBasenameProps {
-  address: `0x${string}`
+  address: `0x${string}`;
+}

--- a/apps/base-docs/sidebar.ts
+++ b/apps/base-docs/sidebar.ts
@@ -1464,11 +1464,11 @@ export const sidebar: Sidebar = [
         items: [
           {
             text: 'Introduction to Foundry ↗',
-            link: 'https://docs.base.org/tutorials/intro-to-foundry-setup',
+            link: '/intro-to-foundry-setup',
           },
           {
             text: 'Testing Smart Contracts ↗',
-            link: 'https://docs.base.org/tutorials/intro-to-foundry-testing',
+            link: '/intro-to-foundry-testing',
           },
         ],
       },


### PR DESCRIPTION
**What changed? Why?**

- Fixed broken links in the sidebar of the BaseDocs website (docs.base.org).
- In the sidebar, under the **Learn** section, there is a **Development With Foundry** subsection.
- The links for "Introduction to Foundry" and "Testing Smart Contracts" were previously pointing to:
  - `https://docs.base.org/tutorials/intro-to-foundry-setup`
  - `https://docs.base.org/tutorials/intro-to-foundry-testing`
- These links were broken and resulted in "Page Not Found" errors.
- Updated the sidebar configuration so these links now point to the correct slugs:
  - `/intro-to-foundry-setup`
  - `/intro-to-foundry-testing`
- This ensures users can access the correct Foundry tutorial documentation from the sidebar.

**Notes to reviewers**

- The change is limited to the sidebar configuration for the BaseDocs site.
- No other files or features were modified.
- Please verify that the sidebar navigation under **Learn > Development With Foundry** now correctly routes to the intended documentation pages.

**How has it been tested?**

- [x] Manual review of the sidebar.ts file to ensure only the intended links were updated.

Have you tested the following pages?

BaseWeb
- [ ] base.org
- [ ] base.org/names
- [ ] base.org/builders
- [ ] base.org/ecosystem
- [ ] base.org/name/jesse
- [ ] base.org/manage-names
- [ ] base.org/resources

BaseDocs
- [x] docs.base.org (sidebar links reviewed)
- [ ] docs sub-pages
