### PR TITLE
chore: Update Dispute Game Addresses in Docs for U15 (Isthmus)

### DIFF
--- a/apps/base-docs/docs/pages/chain/base-contracts.mdx
+++ b/apps/base-docs/docs/pages/chain/base-contracts.mdx
@@ -63,14 +63,14 @@ description: A comprehensive list of L2 contract addresses for Base Mainnet and 
 | DelayedWETHProxy (FDG)       | [0xa2f2aC6F5aF72e494A227d79Db20473Cf7A1FFE8](https://etherscan.io/address/0xa2f2aC6F5aF72e494A227d79Db20473Cf7A1FFE8) |
 | DelayedWETHProxy (PDG)       | [0x3E8a0B63f57e975c268d610ece93da5f78c01321](https://etherscan.io/address/0x3E8a0B63f57e975c268d610ece93da5f78c01321) |
 | DisputeGameFactoryProxy      | [0x43edB88C4B80fDD2AdFF2412A7BebF9dF42cB40e](https://etherscan.io/address/0x43edB88C4B80fDD2AdFF2412A7BebF9dF42cB40e) |
-| FaultDisputeGame             | [0xE17d670043c3cDd705a3223B3D89A228A1f07F0f](https://etherscan.io/address/0xE17d670043c3cDd705a3223B3D89A228A1f07F0f) |
+| FaultDisputeGame             | [0xAB91FB6cef84199145133f75cBD96B8a31F184ED](https://etherscan.io/address/0xAB91FB6cef84199145133f75cBD96B8a31F184ED) |
 | L1CrossDomainMessenger       | [0x866E82a600A1414e583f7F13623F1aC5d58b0Afa](https://etherscan.io/address/0x866E82a600A1414e583f7F13623F1aC5d58b0Afa) |
 | L1ERC721Bridge               | [0x608d94945A64503E642E6370Ec598e519a2C1E53](https://etherscan.io/address/0x608d94945A64503E642E6370Ec598e519a2C1E53) |
 | L1StandardBridge             | [0x3154Cf16ccdb4C6d922629664174b904d80F2C35](https://etherscan.io/address/0x3154Cf16ccdb4C6d922629664174b904d80F2C35) |
 | MIPS                         | [0xF027F4A985560fb13324e943edf55ad6F1d15Dc1](https://etherscan.io/address/0xF027F4A985560fb13324e943edf55ad6F1d15Dc1) |
 | OptimismMintableERC20Factory | [0x05cc379EBD9B30BbA19C6fA282AB29218EC61D84](https://etherscan.io/address/0x05cc379EBD9B30BbA19C6fA282AB29218EC61D84) |
 | OptimismPortal               | [0x49048044D57e1C92A77f79988d21Fa8fAF74E97e](https://etherscan.io/address/0x49048044D57e1C92A77f79988d21Fa8fAF74E97e) |
-| PermissionedDisputeGame      | [0xE749aA49c3eDAF1DCb997eA3DAC23dff72bcb826](https://etherscan.io/address/0xE749aA49c3eDAF1DCb997eA3DAC23dff72bcb826) |
+| PermissionedDisputeGame      | [0x7344Da3A618b86cdA67f8260C0cc2027D99F5B49](https://etherscan.io/address/0x7344Da3A618b86cdA67f8260C0cc2027D99F5B49) |
 | PreimageOracle               | [0x1fb8cdFc6831fc866Ed9C51aF8817Da5c287aDD3](https://etherscan.io/address/0x1fb8cdFc6831fc866Ed9C51aF8817Da5c287aDD3) |
 | ProxyAdmin                   | [0x0475cBCAebd9CE8AfA5025828d5b98DFb67E059E](https://etherscan.io/address/0x0475cBCAebd9CE8AfA5025828d5b98DFb67E059E) |
 | SystemConfig                 | [0x73a79Fab69143498Ed3712e519A88a918e1f4072](https://etherscan.io/address/0x73a79Fab69143498Ed3712e519A88a918e1f4072) |


### PR DESCRIPTION
**What changed? Why?**
Update Dispute Game Addresses in Docs for U15 (Isthmus)

Addresses from: https://github.com/base/contract-deployments/blob/main/mainnet/2025-04-23-upgrade-fault-proofs/addresses.json

**Notes to reviewers**

**How has it been tested?**

Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources

BaseDocs
- [] docs.base.org
- [] docs sub-pages
