### PR TITLE
docs(flashblocks): Fix broken link in node providers section

### DIFF
--- a/apps/base-docs/docs/pages/chain/flashblocks/node-providers.mdx
+++ b/apps/base-docs/docs/pages/chain/flashblocks/node-providers.mdx
@@ -48,4 +48,4 @@ Flashblocks-aware nodes provide all standard Ethereum JSON-RPC methods plus spec
 
 ## Further Resources
 
-For detailed information about node setup, including hardware requirements and additional configuration options, refer to the [Reth node README](https://github.com/base/op-geth/blob/main/node/reth/README.md).
+For detailed information about node setup, including hardware requirements and additional configuration options, refer to the [Reth node README](https://github.com/base/node/tree/main/reth#readme).


### PR DESCRIPTION
**What changed? Why?**

Fix broken link

**Notes to reviewers**

N/A

**How has it been tested?**

Localhost

Have you tested the following pages?

BaseWeb
- [x] base.org
- [x] base.org/names
- [x] base.org/builders
- [x] base.org/ecosystem
- [x] base.org/name/jesse
- [x] base.org/manage-names
- [x] base.org/resources

BaseDocs
- [x] docs.base.org
- [x] docs sub-pages
