### PR TITLE
Fix typos in MiniKit documentation (llms.txt)

### DIFF
--- a/apps/base-docs/docs/public/builderkits/minikit/llms.txt
+++ b/apps/base-docs/docs/public/builderkits/minikit/llms.txt
@@ -322,7 +322,7 @@ Now that you have MiniKit set up, you can:
 Enjoy building!
 # MiniKit Quickstart
 
-This guide shows you how to get started with MiniKit, the easist way to build mini apps on Base! It can also be used to update an exisitng standalone app to a mini app. We'll start by setting up the template project with the CLI tool and then explore both built-in and additional features of MiniKit.
+This guide shows you how to get started with MiniKit, the easiest way to build mini apps on Base! It can also be used to update an existing standalone app to a mini app. We'll start by setting up the template project with the CLI tool and then explore both built-in and additional features of MiniKit.
 
 ## Prerequisites
 
@@ -374,7 +374,7 @@ Alternatively, you can use ngrok to tunnel your localhost to a live url.
 ::::details[Using ngrok]
 
 :::warning[Pitfalls]
-To successfully test your app, you'll need the paid version of ngrok. The free veresion has an approval screen which can break the frame manifest. Also the url for the free version will change every time requiring you to update the manifest each time you start a new ngrok tunnel.
+To successfully test your app, you'll need the paid version of ngrok. The free version has an approval screen which can break the frame manifest. Also the url for the free version will change every time requiring you to update the manifest each time you start a new ngrok tunnel.
 :::
 
 1. Start your development server:


### PR DESCRIPTION


**Description:**  
This pull request corrects several typographical errors in the MiniKit documentation file (`llms.txt`). Specifically, it fixes the words `easist` to `easiest`, `exisitng` to `existing`, and `veresion` to `version`. These changes improve the clarity and professionalism of the documentation. No functional or structural changes were made.

