### PR TITLE
docs: fixed broken links in docs and frontend

### DIFF
--- a/apps/base-docs/docs/pages/cookbook/use-case-guides/gating-and-redirects.mdx
+++ b/apps/base-docs/docs/pages/cookbook/use-case-guides/gating-and-redirects.mdx
@@ -236,7 +236,7 @@ On your own, try changing the "like" gate to require the user to follow you, rec
 
 In this tutorial, you learned how to use the main features of Frames - text input, link buttons, and redirects. You also learned how to use new features in [OnchainKit] to require your users to perform certain actions to unlock features in your Frame. Finally, you learned how to create a loop in your Frame's behavior, which can be used to create very complicated Frames!
 
-[Base Learn]: https://docs.base.org/base-learn/docs/welcome
+[Base Learn]: https://docs.base.org/learn/welcome
 [Farcaster]: https://www.farcaster.xyz/
 [a-frame-in-100-lines]: https://github.com/Zizzamia/a-frame-in-100-lines
 [OnchainKit]: https://onchainkit.xyz/?utm_source=basedocs&utm_medium=tutorials&campaign=farcaster-frames-gating-and-redirects

--- a/apps/base-docs/docs/pages/cookbook/use-case-guides/transactions.mdx
+++ b/apps/base-docs/docs/pages/cookbook/use-case-guides/transactions.mdx
@@ -350,7 +350,7 @@ contract ClickTheButton is Ownable {
 }
 ```
 
-[Base Learn]: https://docs.base.org/base-learn/docs/welcome
+[Base Learn]: https://docs.base.org/learn/welcome
 [Farcaster]: https://www.farcaster.xyz/
 [a-frame-in-100-lines]: https://github.com/Zizzamia/a-frame-in-100-lines
 [OnchainKit]: https://onchainkit.xyz/?utm_source=basedocs&utm_medium=tutorials&campaign=farcaster-frames-transactions

--- a/apps/base-docs/docs/pages/learn/reading-and-displaying-data/useReadContract.mdx
+++ b/apps/base-docs/docs/pages/learn/reading-and-displaying-data/useReadContract.mdx
@@ -455,7 +455,7 @@ contract FEWeightedVoting is ERC20 {
 [Wallet Connectors]: ../frontend-setup/wallet-connectors/
 [`useAccount`]: https://wagmi.sh/react/hooks/useAccount
 [hydration error]: https://nextjs.org/docs/messages/react-hydration-error
-[ERC 20 Tokens Exercise]: https://docs.base.org/base-learn/docs/erc-20-token/erc-20-exercise
+[ERC 20 Tokens Exercise]: https://docs.base.org/learn/erc-20-token/erc-20-exercise
 [Sepolia BaseScan]: https://sepolia.basescan.org/
 [`useAccount` hook]: ./useAccount
 [Hardhat]: https://hardhat.org/

--- a/apps/web/src/components/Bootcamp/HowItWorks/index.tsx
+++ b/apps/web/src/components/Bootcamp/HowItWorks/index.tsx
@@ -38,7 +38,7 @@ const featureItems = [
           <a
             className="underline"
             target="_blank"
-            href="https://docs.base.org/base-learn/docs/welcome"
+            href="https://docs.base.org/learn/welcome"
             rel="noreferrer"
           >
             Base Learn


### PR DESCRIPTION
**What changed? Why?**

Hi! Just cleaned up a few outdated links that were pointing to deprecated paths. All updated to use the correct `docs.base.org/learn` structure.

**Notes to reviewers**

**How has it been tested?**

Have you tested the following pages?

BaseWeb
- [x] base.org
- [x] base.org/names
- [x] base.org/builders
- [x] base.org/ecosystem
- [x] base.org/name/jesse
- [x] base.org/manage-names
- [x] base.org/resources

BaseDocs
- [x] docs.base.org
- [x] docs sub-pages
