### PR TITLE
chore: removed no more relevant reminder

### DIFF
--- a/apps/web/src/components/Layout/Footer/Footer.tsx
+++ b/apps/web/src/components/Layout/Footer/Footer.tsx
@@ -25,7 +25,7 @@ const LINK_SECTIONS = [
         href: 'https://docs.base.org/identity/smart-wallet/introduction/base-gasless-campaign',
       },
       { label: 'Engineering blog', href: 'https://www.base.dev/blog' },
-      { label: 'Support', href: 'https://discord.com/invite/buildonbase' }, // TODO: add discord link
+      { label: 'Support', href: 'https://discord.com/invite/buildonbase' },
     ],
   },
   {


### PR DESCRIPTION
there was a TODO with a reminder to add a discord link, 

since the link is already there, 

I suppose there's no need in the TODO reminder anymore