### PR TITLE
Fix Broken Documentation Link for Supra Oracles

### DIFF
--- a/apps/base-docs/docs/pages/chain/oracles.mdx
+++ b/apps/base-docs/docs/pages/chain/oracles.mdx
@@ -134,7 +134,7 @@ See [this guide](https://docs.redstone.finance/) to learn how to use the RedSton
 
 [Supra](https://supraoracles.com) provides VRF and decentralized oracle price feeds that can be used for onchain and offchain use-cases such as spot and perpetual DEXes, lending protocols, and payments protocols. Supra’s oracle chain and consensus algorithm makes it one of the fastest-to-finality oracle providers, with layer-1 security guarantees. The pull oracle has a sub-second response time. Aside from speed and security, Supra’s rotating node architecture gathers data from 40+ data sources and applies a robust calculation methodology to get the most accurate value. The node provenance on the data dashboard also provides a fully transparent historical audit trail. Supra’s Distributed Oracle Agreement (DORA) paper was accepted into ICDCS 2023, the oldest distributed systems conference.
 
-Visit the Supra [documentation](https://supraoracles.com/docs/) to learn more about integrating Supra's oracle and VRF into your Base project.
+Visit the Supra [documentation](https://docs.supra.com/) to learn more about integrating Supra's oracle and VRF into your Base project.
 
 #### Supported Networks
 

--- a/apps/base-docs/docs/public/llms-full.txt
+++ b/apps/base-docs/docs/public/llms-full.txt
@@ -843,7 +843,7 @@ See [this guide](https://docs.redstone.finance/) to learn how to use the RedSton
 
 [Supra](https://supraoracles.com/) provides VRF and decentralized oracle price feeds that can be used for onchain and offchain use-cases such as spot and perpetual DEXes, lending protocols, and payments protocols. Supra’s oracle chain and consensus algorithm makes it one of the fastest-to-finality oracle providers, with layer-1 security guarantees. The pull oracle has a sub-second response time. Aside from speed and security, Supra’s rotating node architecture gathers data from 40+ data sources and applies a robust calculation methodology to get the most accurate value. The node provenance on the data dashboard also provides a fully transparent historical audit trail. Supra’s Distributed Oracle Agreement (DORA) paper was accepted into ICDCS 2023, the oldest distributed systems conference.
 
-Visit the Supra [documentation](https://supraoracles.com/docs/) to learn more about integrating Supra's oracle and VRF into your Base project.
+Visit the Supra [documentation](https://docs.supra.com/) to learn more about integrating Supra's oracle and VRF into your Base project.
 
 #### Supported Networks
 


### PR DESCRIPTION
This PR updates broken links to the Supra Oracles documentation. The original link https://supraoracles.com/docs/ currently results in a 404 error. It has been replaced with the correct and working link: https://docs.supra.com/.

