### PR TITLE
Fix typos in MiniKit Quickstart documentation

### DIFF
--- a/apps/base-docs/docs/pages/builderkits/minikit/quickstart.mdx
+++ b/apps/base-docs/docs/pages/builderkits/minikit/quickstart.mdx
@@ -115,7 +115,7 @@ The template comes with several pre-implemented features. Let's explore where th
 
 ### MiniKitProvider
 
-The `MiniKitProvider` is set up in your `providers.tsx` file. It wraps your application to handle initialization, events, and automatically applie client safeAreaInsets to ensure your app doesn't overlap parent application elements.
+The `MiniKitProvider` is set up in your `providers.tsx` file. It wraps your application to handle initialization, events, and automatically applies client safeAreaInsets to ensure your app doesn't overlap parent application elements.
 
 ```tsx [app/providers.tsx]
 import { MiniKitProvider } from '@coinbase/onchainkit/minikit';
@@ -234,7 +234,7 @@ const openUrl = useOpenUrl()
 </footer>
 ```
 
-Now that we've reviewed the MiniKit teamplate and the functionality already implemented, lets add some additional MiniKit features.
+Now that we've reviewed the MiniKit template and the functionality already implemented, lets add some additional MiniKit features.
 
 ## Additional MiniKit Features
 


### PR DESCRIPTION


**Description:**  
This pull request corrects two typographical errors in the MiniKit Quickstart documentation:
- Replaces "applie" with "applies" in the MiniKitProvider section.
- Fixes "teamplate" to "template" in the review section.

These changes improve the clarity and professionalism of the documentation. No functional code changes were made.
