### PR TITLE
Fix: use new talentprotocol endpoint to fetch builder score

### DIFF
--- a/apps/web/app/(basenames)/api/basenames/talentprotocol/[address]/route.ts
+++ b/apps/web/app/(basenames)/api/basenames/talentprotocol/[address]/route.ts
@@ -13,7 +13,7 @@ export async function GET(
 
   try {
     const response = await fetch(
-      `https://api.talentprotocol.com/api/v2/passports/${encodeURIComponent(address)}`,
+      `https://api.talentprotocol.com/score?id=${encodeURIComponent(address)}`,
       {
         method: 'GET',
         headers: {

--- a/apps/web/src/components/Basenames/UsernameProfileSectionBadges/hooks/useTalentProtocol.ts
+++ b/apps/web/src/components/Basenames/UsernameProfileSectionBadges/hooks/useTalentProtocol.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 
-async function fetchPassport(address: `0x${string}`): Promise<Data> {
+async function fetchScore(address: `0x${string}`): Promise<Data> {
   const response = await fetch(`/api/basenames/talentprotocol/${address}`);
   const data = (await response.json()) as Data;
   return data;
@@ -17,7 +17,7 @@ type Data = {
 export function useTalentProtocol(address?: `0x${string}`) {
   const query = useQuery<Data>({
     queryKey: ['talent-protocol', address],
-    queryFn: async ({ queryKey }) => fetchPassport(queryKey[1] as `0x${string}`),
+    queryFn: async ({ queryKey }) => fetchScore(queryKey[1] as `0x${string}`),
     enabled: !!address,
   });
 

--- a/apps/web/src/components/Basenames/UsernameProfileSectionBadges/hooks/useTalentProtocol.ts
+++ b/apps/web/src/components/Basenames/UsernameProfileSectionBadges/hooks/useTalentProtocol.ts
@@ -7,8 +7,9 @@ async function fetchPassport(address: `0x${string}`): Promise<Data> {
 }
 
 type Data = {
-  passport: {
-    score: number;
+  score: {
+    points: number;
+    v1_score: number;
   };
   error?: string;
 };
@@ -24,8 +25,7 @@ export function useTalentProtocol(address?: `0x${string}`) {
     if (query.data.error) {
       return undefined;
     }
-
-    return query.data.passport.score;
+    return query.data.score.points;
   }
 
   return undefined;


### PR DESCRIPTION
**What changed? Why?**

Talent protocol deprecated their old passport endpoint and suggested we update to using the new `v2/score` endpoint: https://docs.talentprotocol.com/docs/developers/talent-api/api-reference-v2/score

Updated the route and the return data struct to match the new endpoint's response. 


**Notes to reviewers**

**How has it been tested?**

Local branch fetched the score correctly. 

On prod: 

![Screenshot 2025-05-12 at 11 46 36 AM](https://github.com/user-attachments/assets/98cc96ca-2bd3-43d6-8442-5bf681331127)

On local: 
![Screenshot 2025-05-12 at 11 46 31 AM](https://github.com/user-attachments/assets/2069351f-4347-4fed-84a6-4aa3584e23bd)

Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources

BaseDocs
- [] docs.base.org
- [] docs sub-pages
