### PR TITLE
Fix typos in MiniKit documentation

### DIFF
--- a/apps/base-docs/docs/public/builderkits/minikit/llms.txt
+++ b/apps/base-docs/docs/public/builderkits/minikit/llms.txt
@@ -492,7 +492,7 @@ Enter `y` to proceed with the setup and your browser will open to the following 
   height="364"
 />
 
-The wallet that you connect must be your Farcaster custody wallet. You can import this wallet to your prefered wallet using the recovery phrase. You can find your recovery phrase in the Warpcast app under Settings -> Advanced -> Farcster recovery phrase.
+The wallet that you connect must be your Farcaster custody wallet. You can import this wallet to your prefered wallet using the recovery phrase. You can find your recovery phrase in the Warpcast app under Settings -> Advanced -> Farcaster recovery phrase.
 
 Once connected, add the vercel url and sign the manifest. This will automatically update your .env variables locally, but we'll need to update Vercel's .env variables.
 
@@ -587,7 +587,7 @@ If you reload the frame in the Warpcast dev tools preview, you'll now see the cl
 
 The Primary Button is a button that always exists at the bottom of the frame. Its good for managing global state which is relevant throughout your mini app.
 
-For the template example, we'll use the Priamry Button to Pause and Restart the game. The game state is managed within the `snake.tsx` component, and we can easily add the `usePrimaryButton` hook there since the MiniKit hooks are available throughout the app.
+For the template example, we'll use the Primary Button to Pause and Restart the game. The game state is managed within the `snake.tsx` component, and we can easily add the `usePrimaryButton` hook there since the MiniKit hooks are available throughout the app.
 
 ```tsx [/app/components/snake.tsx]
 // add an import for usePrimaryButton


### PR DESCRIPTION
**What changed? Why?**

**Description:**  
This pull request corrects two typographical errors in the MiniKit documentation file (`llms.txt`):

- Replaces "Farcster" with the correct spelling "Farcaster" in the instructions for wallet recovery.
- Fixes "Priamry" to "Primary" in the section describing the Primary Button example.

These changes improve the accuracy and professionalism of the documentation. No functional code changes were made.
