### PR TITLE
fix: function name error

### DIFF
--- a/apps/base-docs/docs/pages/learn/error-triage/error-triage.mdx
+++ b/apps/base-docs/docs/pages/learn/error-triage/error-triage.mdx
@@ -427,7 +427,7 @@ Fix by changing your code to handle the expected range of values.
 
 
 ```solidity
-function badSubstractionFixed() public pure returns (int) {
+function badSubtractionFixed() public pure returns (int) {
     int first = 1;
     int second = 2;
     return first - second;


### PR DESCRIPTION
**What changed? Why?**

**Notes to reviewers**

**How has it been tested?**

Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources

BaseDocs
- [] docs.base.org
- [] docs sub-pages
