### PR TITLE
Fix broken image link in mobile wallet protocol verification docs

### DIFF
--- a/apps/base-docs/docs/pages/identity/mobile-wallet-protocol/verification.mdx
+++ b/apps/base-docs/docs/pages/identity/mobile-wallet-protocol/verification.mdx
@@ -10,5 +10,5 @@ Decentralized verification of participating apps’ authenticity using [.well-kn
 
 MWP host wallets load metadata from the iOS App Store / Android package manager with the client app's `appId`.
 
-![](img/handshake.png)
+![](/images/mobile-wallet-protocol/handshake.png)
 


### PR DESCRIPTION
**What changed? Why?**

Updated the image path for the handshake diagram in verification.mdx to point to the correct location in /images/mobile-wallet-protocol/handshake.png, resolving a missing file error in the documentation.
