### PR TITLE
Fix broken anchor link to message content encryption section in messages docs

### DIFF
--- a/apps/base-docs/docs/pages/identity/mobile-wallet-protocol/messages.mdx
+++ b/apps/base-docs/docs/pages/identity/mobile-wallet-protocol/messages.mdx
@@ -37,7 +37,7 @@ Unique id of the message
 Public key of the sender in base64 encoded string
 
 ### `content`
-[Message's content](encryption#message-encryption) which might be encrypted by the sender using the derived shared secret
+[Message's content](/identity/mobile-wallet-protocol/encryption#message-content-encryption) which might be encrypted by the sender using the derived shared secret
 
 ### `timestamp`
 UNIX millisecond timestamp


### PR DESCRIPTION
**What changed? Why?**

Updated the reference to the message content encryption section in messages.mdx to use the correct absolute path (/identity/mobile-wallet-protocol/encryption#message-content-encryption), ensuring the link navigates properly within the documentation.

**Notes to reviewers**

**How has it been tested?**

Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources

BaseDocs
- [] docs.base.org
- [] docs sub-pages
