### PR TITLE
correction gas-use-in-eth-transactions.mdx

### DIFF
--- a/apps/base-docs/docs/pages/learn/introduction-to-ethereum/gas-use-in-eth-transactions.mdx
+++ b/apps/base-docs/docs/pages/learn/introduction-to-ethereum/gas-use-in-eth-transactions.mdx
@@ -39,11 +39,11 @@ Gas costs can also vary depending on the state of the network, or more specifica
 
 ### Turing Completeness
 
-As we've learned, Ethereum is a Turing-complete platform, which means that any program that can be represented in code can theoretically be expressed and executed on the network. This opens up the door to countless different types of applications that can be built, but it also creates the possibility that malicious or inefficient code can clog up the network, potentially leading to denial-of-service attacks, network spam, and other problems.
+As we've learned, Ethereum is a Turing-complete platform, which means that any program that can be represented in code can theoretically be expressed and executed on the network. This opens the door to countless different types of applications that can be built, but it also creates the possibility that malicious or inefficient code can clog up the network, potentially leading to denial-of-service attacks, network spam, and other problems.
 
 ### Preventing Infinite Loops
 
-Gas to the rescue! To prevent accidental or intentional infinite loops in smart contract code, Ethereum requires that every transaction specify a gas limit. The gas limit establishes the maximum amount of gas that the transaction can consume, and they ensure that transactions are executed within a predetermined amount of computational resources, preventing the execution of code that might consume too much computation power and potentially cause the network to freeze or crash. Without gas, Ethereum's Turing completeness would be insecure and inefficient.
+Gas to the rescue! To prevent accidental or intentional infinite loops in smart contract code, Ethereum requires that every transaction specify a gas limit. The gas limit establishes the maximum amount of gas that the transaction can consume, and it ensure that transactions are executed within a predetermined amount of computational resources, preventing the execution of code that might consume too much computation power and potentially cause the network to freeze or crash. Without gas, Ethereum's Turing completeness would be insecure and inefficient.
 
 ### Autonomous Execution
 
@@ -87,7 +87,7 @@ Consider Alice wants to send some ETH to Bob. Alice specifies a gas limit of 100
 
 The EVM, upon receiving Alice's transaction, starts executing it. As the transaction is processed, the EVM deducts the used gas from the gas limit. If the transaction completes before reaching the gas limit, the remaining unused gas is refunded to Alice's account.
 
-Let's illustrate this with a couple scenarios:
+Let's illustrate this with a couple of scenarios:
 
 - Suppose the transaction used 80,000 units of gas, leaving 20,000 units unused. Since the gas price was set at 10 gwei per unit, Alice would receive a refund of 0.0002 ETH (200,000 gwei) for the unused gas.
 
@@ -95,7 +95,7 @@ Let's illustrate this with a couple scenarios:
 
 ### Gas Estimation
 
-Gas estimation is another key concept to understand. It refers to the process of predicting the amount of gas that will be required to execute a transaction. This is important because as we've seen in our example, the gas limit of a transaction needs to be set before it can be broadcasted to the network. If the gas limit is set too low, the transaction may fail to execute, while if it is set too high, the sender may end up paying more in transaction fees than is necessary.
+Gas estimation is another key concept to understand. It refers to the process of predicting the amount of gas that will be required to execute a transaction. This is important because as we've seen in our example, the gas limit of a transaction needs to be set before it can be broadcast to the network. If the gas limit is set too low, the transaction may fail to execute, while if it is set too high, the sender may end up paying more in transaction fees than is necessary.
 
 There are several methods that can be used for gas estimation. One common method is to use historical gas prices and gas limits as a reference point, and to estimate the gas needed for a new transaction based on the gas used in similar past transactions. Another method is to simulate the execution of the transaction in a test environment to determine the actual amount of gas that would be used.
 


### PR DESCRIPTION
**What changed? Why?**

`opens up the` - `opens the`
`and they ensure` - `and it ensure`
`couple scenarios` - `couple of scenarios`
`broadcasted` - `broadcast`