### PR TITLE
fix(node-performance): Update recommended LevelDB block size

### DIFF
--- a/apps/base-docs/docs/pages/chain/node-performance.mdx
+++ b/apps/base-docs/docs/pages/chain/node-performance.mdx
@@ -96,7 +96,7 @@ Recommended LevelDB environment variable values with this patch:
 
 ```bash
 # Recommended LevelDB Settings
-LDB_BLOCK_SIZE="524288" # 512 KiB block size (matches common RAID 0 chunk sizes)
+LDB_BLOCK_SIZE="16384" # 16 KiB block size
 LDB_COMPACTION_TABLE_SIZE="8388608" # 8 MiB compaction table size (default: 2 MiB)
 LDB_COMPACTION_TOTAL_SIZE="41943040" # 40 MiB total compaction size (default: 8 MiB)
 LDB_DEBUG_OPTIONS="1" # Emit LevelDB debug logs


### PR DESCRIPTION
**What changed? Why?**

Updates the recommended block size for LevelDB

**Notes to reviewers**

**How has it been tested?**

Localhost

Have you tested the following pages?

BaseWeb
- [x] base.org
- [x] base.org/names
- [x] base.org/builders
- [x] base.org/ecosystem
- [x] base.org/name/jesse
- [x] base.org/manage-names
- [x] base.org/resources

BaseDocs
- [x] docs.base.org
- [x] docs sub-pages
