### PR TITLE
fix: update Farcaster Frames documentation link to the correct URL

### DIFF
--- a/apps/base-docs/docs/pages/cookbook/use-case-guides/cast-actions.mdx
+++ b/apps/base-docs/docs/pages/cookbook/use-case-guides/cast-actions.mdx
@@ -192,7 +192,7 @@ Watch the [Base Channel] to stay up-to-date on new developments!
 [Frame Validator]: https://warpcast.com/~/developers/frames
 [Base channel]: https://warpcast.com/~/channel/base
 [deploying with Vercel]: /tutorials/farcaster-frames-deploy-to-vercel
-[Frame]: https://docs.farcaster.xyz/learn/what-is-farcaster/frames
-[Frames]: https://docs.farcaster.xyz/learn/what-is-farcaster/frames
+[Frames]: https://docs.farcaster.xyz/developers/frames/
+[Frame]: https://docs.farcaster.xyz/developers/frames/
 [Cast Actions]: https://warpcast.notion.site/Spec-Farcaster-Actions-84d5a85d479a43139ea883f6823d8caa
 


### PR DESCRIPTION
This commit replaces the outdated and broken Farcaster Frames documentation link (https://docs.farcaster.xyz/learn/what-is-farcaster/frames) with the correct, working URL:
https://docs.farcaster.xyz/developers/frames/
This ensures users are directed to the up-to-date and relevant documentation about Farcaster Frames, as per the official Farcaster docs
https://docs.farcaster.xyz/developers/frames/