### PR TITLE
[BA-1973] Basenames renewals page

### DIFF
--- a/apps/web/app/(basenames)/name/[username]/renew/page.tsx
+++ b/apps/web/app/(basenames)/name/[username]/renew/page.tsx
@@ -1,0 +1,19 @@
+import ErrorsProvider from 'apps/web/contexts/Errors';
+import RenewalFlow from 'apps/web/src/components/Basenames/RenewalFlow';
+
+type PageProps = {
+  params: Promise<{ username: string }>;
+};
+
+export default async function Page(props: PageProps) {
+  const params = await props.params;
+  const { username } = params;
+
+  return (
+    <ErrorsProvider context="renewal">
+      <main>
+        <RenewalFlow name={username} />
+      </main>
+    </ErrorsProvider>
+  );
+}

--- a/apps/web/app/(basenames)/name/[username]/renew/page.tsx
+++ b/apps/web/app/(basenames)/name/[username]/renew/page.tsx
@@ -8,11 +8,12 @@ type PageProps = {
 export default async function Page(props: PageProps) {
   const params = await props.params;
   const { username } = params;
+  const name = username.split('.')[0];
 
   return (
     <ErrorsProvider context="renewal">
       <main>
-        <RenewalFlow name={username} />
+        <RenewalFlow name={name} />
       </main>
     </ErrorsProvider>
   );

--- a/apps/web/src/components/Basenames/RegistrationBackground/index.tsx
+++ b/apps/web/src/components/Basenames/RegistrationBackground/index.tsx
@@ -4,7 +4,6 @@ import { FloatingENSPills } from 'apps/web/src/components/Basenames/FloatingENSP
 import {
   RegistrationSteps,
   registrationTransitionDuration,
-  useRegistration,
 } from 'apps/web/src/components/Basenames/RegistrationContext';
 
 import fireworks from './assets/fireworks.webm';
@@ -13,9 +12,11 @@ import vortexJson from './assets/vortex.json';
 import classNames from 'classnames';
 import LottieAnimation from 'apps/web/src/components/LottieAnimation';
 
-export default function RegistrationBackground() {
-  const { registrationStep } = useRegistration();
-
+export default function RegistrationBackground({
+  registrationStep,
+}: {
+  registrationStep: RegistrationSteps;
+}) {
   const isSearch = registrationStep === RegistrationSteps.Search;
   const isClaim = registrationStep === RegistrationSteps.Claim;
   const isPending = registrationStep === RegistrationSteps.Pending;

--- a/apps/web/src/components/Basenames/RegistrationFlow.tsx
+++ b/apps/web/src/components/Basenames/RegistrationFlow.tsx
@@ -359,7 +359,7 @@ export function RegistrationFlow() {
         </Transition>
 
         {/* Misc: Animated background for each steps */}
-        <RegistrationBackground />
+        <RegistrationBackground registrationStep={registrationStep} />
       </section>
     </>
   );

--- a/apps/web/src/components/Basenames/RegistrationForm/index.tsx
+++ b/apps/web/src/components/Basenames/RegistrationForm/index.tsx
@@ -1,9 +1,4 @@
-import {
-  ExclamationCircleIcon,
-  InformationCircleIcon,
-  MinusIcon,
-  PlusIcon,
-} from '@heroicons/react/16/solid';
+import { ExclamationCircleIcon, InformationCircleIcon } from '@heroicons/react/16/solid';
 import { useAnalytics } from 'apps/web/contexts/Analytics';
 import { useErrors } from 'apps/web/contexts/Errors';
 import RegistrarControllerABI from 'apps/web/src/abis/RegistrarControllerABI';
@@ -11,6 +6,7 @@ import { USERNAME_REGISTRAR_CONTROLLER_ADDRESSES } from 'apps/web/src/addresses/
 import { PremiumExplainerModal } from 'apps/web/src/components/Basenames/PremiumExplainerModal';
 import { useRegistration } from 'apps/web/src/components/Basenames/RegistrationContext';
 import RegistrationLearnMoreModal from 'apps/web/src/components/Basenames/RegistrationLearnMoreModal';
+import YearSelector from 'apps/web/src/components/Basenames/YearSelector';
 import { Icon } from 'apps/web/src/components/Icon/Icon';
 import Label from 'apps/web/src/components/Label';
 import Tooltip from 'apps/web/src/components/Tooltip';
@@ -190,29 +186,12 @@ export default function RegistrationForm() {
           )}
           <div className={mainRegistrationElementClasses}>
             <div className="max-w-[14rem] self-start">
-              <p className="text-line mb-2 text-sm font-bold uppercase">Claim for</p>
-              <div className="flex items-center justify-between">
-                <button
-                  type="button"
-                  onClick={decrement}
-                  disabled={years === 1}
-                  className="flex h-7 w-7 items-center justify-center rounded-full bg-[#DEE1E7]"
-                  aria-label="Decrement years"
-                >
-                  <MinusIcon width="14" height="14" className="fill-[#32353D]" />
-                </button>
-                <span className="flex w-32 items-center justify-center text-3xl font-bold text-black">
-                  {years} year{years > 1 && 's'}
-                </span>
-                <button
-                  type="button"
-                  onClick={increment}
-                  className="flex h-7 w-7 items-center justify-center rounded-full bg-[#DEE1E7]"
-                  aria-label="Increment years"
-                >
-                  <PlusIcon width="14" height="14" className="fill-[#32353D]" />
-                </button>
-              </div>
+              <YearSelector
+                years={years}
+                onIncrement={increment}
+                onDecrement={decrement}
+                label="Claim for"
+              />
               {hasExistingBasename && (
                 <Label
                   className="mt-4 flex w-full items-center justify-center gap-2 text-center"

--- a/apps/web/src/components/Basenames/RegistrationForm/index.tsx
+++ b/apps/web/src/components/Basenames/RegistrationForm/index.tsx
@@ -26,26 +26,9 @@ import { ActionType } from 'libs/base-ui/utils/logEvent';
 import { ChangeEvent, useCallback, useMemo, useState } from 'react';
 import { formatEther, zeroAddress } from 'viem';
 import { useAccount, useBalance, useReadContract, useSwitchChain } from 'wagmi';
+import { formatEtherPrice } from 'apps/web/src/utils/formatEtherPrice';
+import { formatUsdPrice } from 'apps/web/src/utils/formatUsdPrice';
 import { RegistrationButton } from './RegistrationButton';
-
-export function formatEtherPrice(price?: bigint) {
-  if (price === undefined) {
-    return '...';
-  }
-  const value = parseFloat(formatEther(price));
-  if (value < 0.001) {
-    return parseFloat(value.toFixed(4));
-  } else {
-    return parseFloat(value.toFixed(3));
-  }
-}
-
-export function formatUsdPrice(price: bigint, ethUsdPrice: number) {
-  if (price === 0n) return '0';
-  const parsed = (parseFloat(formatEther(price)) * Number(ethUsdPrice)).toFixed(2);
-  if (parsed === '0.00') return '0';
-  return parsed;
-}
 
 export default function RegistrationForm() {
   const { isConnected, chain: connectedChain, address } = useAccount();

--- a/apps/web/src/components/Basenames/RegistrationForm/index.tsx
+++ b/apps/web/src/components/Basenames/RegistrationForm/index.tsx
@@ -32,7 +32,7 @@ import { formatEther, zeroAddress } from 'viem';
 import { useAccount, useBalance, useReadContract, useSwitchChain } from 'wagmi';
 import { RegistrationButton } from './RegistrationButton';
 
-function formatEtherPrice(price?: bigint) {
+export function formatEtherPrice(price?: bigint) {
   if (price === undefined) {
     return '...';
   }
@@ -44,7 +44,7 @@ function formatEtherPrice(price?: bigint) {
   }
 }
 
-function formatUsdPrice(price: bigint, ethUsdPrice: number) {
+export function formatUsdPrice(price: bigint, ethUsdPrice: number) {
   if (price === 0n) return '0';
   const parsed = (parseFloat(formatEther(price)) * Number(ethUsdPrice)).toFixed(2);
   if (parsed === '0.00') return '0';
@@ -300,7 +300,9 @@ export default function RegistrationForm() {
                 correctChain={correctChain}
                 registerNameCallback={registerNameCallback}
                 switchToIntendedNetwork={switchToIntendedNetwork}
-                insufficientFundsNoAuxFundsAndCorrectChain={insufficientFundsNoAuxFundsAndCorrectChain}
+                insufficientFundsNoAuxFundsAndCorrectChain={
+                  insufficientFundsNoAuxFundsAndCorrectChain
+                }
                 registerNameIsPending={registerNameIsPending}
               />
             </div>

--- a/apps/web/src/components/Basenames/RenewalFlow.tsx
+++ b/apps/web/src/components/Basenames/RenewalFlow.tsx
@@ -1,5 +1,4 @@
 'use client';
-import dynamic from 'next/dynamic';
 import { Transition } from '@headlessui/react';
 import RegistrationBackground from 'apps/web/src/components/Basenames/RegistrationBackground';
 import RenewalForm from 'apps/web/src/components/Basenames/RenewalForm';
@@ -9,13 +8,10 @@ import useBasenameChain, { supportedChainIds } from 'apps/web/src/hooks/useBasen
 import classNames from 'classnames';
 import { useCallback, useEffect, useMemo } from 'react';
 import { useAccount, useSwitchChain } from 'wagmi';
-import { isDevelopment } from 'libs/base-ui/constants';
 import { Basename } from '@coinbase/onchainkit/identity';
-
-const RegistrationStateSwitcherDynamic = dynamic(
-  async () => import('apps/web/src/components/Basenames/RegistrationStateSwitcher'),
-  { ssr: false },
-);
+import { Icon } from 'apps/web/src/components/Icon/Icon';
+import { useRouter } from 'next/navigation';
+import { RegistrationSteps } from 'apps/web/src/components/Basenames/RegistrationContext';
 
 type RenewalFlowProps = {
   name: string;
@@ -25,6 +21,7 @@ export function RenewalFlow({ name }: RenewalFlowProps) {
   const { chain } = useAccount();
   const { basenameChain } = useBasenameChain();
   const { switchChain } = useSwitchChain();
+  const router = useRouter();
 
   const isOnSupportedNetwork = useMemo(
     () => chain && supportedChainIds.includes(chain.id),
@@ -35,6 +32,10 @@ export function RenewalFlow({ name }: RenewalFlowProps) {
     () => switchChain({ chainId: basenameChain.id }),
     [basenameChain.id, switchChain],
   );
+
+  const onBackArrowClick = useCallback(() => {
+    router.back();
+  }, [router]);
 
   useEffect(() => {
     if (!chain || !switchToIntendedNetwork) {
@@ -60,60 +61,68 @@ export function RenewalFlow({ name }: RenewalFlowProps) {
   const currentUsernamePillVariant = UsernamePillVariants.Inline;
 
   return (
-    <>
-      {true && isDevelopment && <RegistrationStateSwitcherDynamic />}
-      <section className={mainClasses}>
-        {/* Username Pill */}
-        <div className="relative flex w-full max-w-full flex-col items-center justify-center md:-translate-y-12">
-          <Transition
-            appear
-            show
-            className={classNames(
-              'relative z-10 w-full max-w-full transition-opacity',
-              renewalTransitionDuration,
-            )}
-            enterFrom="opacity-0"
-            enterTo="opacity-100"
-            leaveFrom="opacity-100"
-            leaveTo="opacity-0"
-          >
-            {/* The pill */}
-            <Transition
-              appear
-              show
-              className={classNames(
-                'transition-[max-width, transform] mx-auto',
-                renewalTransitionDuration,
-              )}
-              enterFrom="max-w-0"
-              enterTo="max-w-full"
+    <section className={mainClasses}>
+      {/* Username Pill */}
+      <div className="relative flex w-full max-w-full flex-col items-center justify-center md:-translate-y-12">
+        <Transition
+          appear
+          show
+          className={classNames(
+            'relative z-10 w-full max-w-full transition-opacity',
+            renewalTransitionDuration,
+          )}
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div className="absolute left-1/2 z-9 mx-auto w-full -translate-x-1/2 -translate-y-[calc(15vh)] gap-4 px-2 transition-opacity md:max-w-[16rem] md:-translate-y-20">
+            <button
+              onClick={onBackArrowClick}
+              type="button"
+              aria-label="Find another name"
+              className="flex items-center gap-6"
             >
-              <UsernamePill variant={currentUsernamePillVariant} username={name as Basename} />
-            </Transition>
-          </Transition>
-
-          {/* Renewal Form */}
+              <Icon name="backArrow" color="currentColor" height="1rem" width="1rem" />
+              <p className="text-gray-50">EXTEND REGISTRATION</p>
+            </button>
+          </div>
+          {/* The pill */}
           <Transition
             appear
             show
             className={classNames(
-              'relative z-40 transition-opacity',
-              'mx-auto',
+              'transition-[max-width, transform] mx-auto',
               renewalTransitionDuration,
             )}
-            enterFrom="opacity-0"
-            enterTo="opacity-100"
-            leaveFrom="opacity-100"
-            leaveTo="opacity-0"
+            enterFrom="max-w-0"
+            enterTo="max-w-full"
           >
-            <RenewalForm name={name} />
+            <UsernamePill variant={currentUsernamePillVariant} username={name as Basename} />
           </Transition>
-        </div>
+        </Transition>
 
-        {/* Animated background for each step */}
-        <RegistrationBackground />
-      </section>
-    </>
+        {/* Renewal Form */}
+        <Transition
+          appear
+          show
+          className={classNames(
+            'relative z-40 transition-opacity',
+            'mx-auto',
+            renewalTransitionDuration,
+          )}
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <RenewalForm name={name} />
+        </Transition>
+      </div>
+
+      {/* The renewal flow should only display the Claim background */}
+      <RegistrationBackground registrationStep={RegistrationSteps.Claim} />
+    </section>
   );
 }
 

--- a/apps/web/src/components/Basenames/RenewalFlow.tsx
+++ b/apps/web/src/components/Basenames/RenewalFlow.tsx
@@ -8,10 +8,8 @@ import useBasenameChain, { supportedChainIds } from 'apps/web/src/hooks/useBasen
 import classNames from 'classnames';
 import { useCallback, useEffect, useMemo } from 'react';
 import { useAccount, useSwitchChain } from 'wagmi';
-import { Basename } from '@coinbase/onchainkit/identity';
-import { Icon } from 'apps/web/src/components/Icon/Icon';
-import { useRouter } from 'next/navigation';
 import { RegistrationSteps } from 'apps/web/src/components/Basenames/RegistrationContext';
+import { formatBaseEthDomain } from 'apps/web/src/utils/usernames';
 
 type RenewalFlowProps = {
   name: string;
@@ -21,7 +19,6 @@ export function RenewalFlow({ name }: RenewalFlowProps) {
   const { chain } = useAccount();
   const { basenameChain } = useBasenameChain();
   const { switchChain } = useSwitchChain();
-  const router = useRouter();
 
   const isOnSupportedNetwork = useMemo(
     () => chain && supportedChainIds.includes(chain.id),
@@ -32,10 +29,6 @@ export function RenewalFlow({ name }: RenewalFlowProps) {
     () => switchChain({ chainId: basenameChain.id }),
     [basenameChain.id, switchChain],
   );
-
-  const onBackArrowClick = useCallback(() => {
-    router.back();
-  }, [router]);
 
   useEffect(() => {
     if (!chain || !switchToIntendedNetwork) {
@@ -76,17 +69,9 @@ export function RenewalFlow({ name }: RenewalFlowProps) {
           leaveFrom="opacity-100"
           leaveTo="opacity-0"
         >
-          <div className="absolute left-1/2 z-9 mx-auto w-full -translate-x-1/2 -translate-y-[calc(15vh)] gap-4 px-2 transition-opacity md:max-w-[16rem] md:-translate-y-20">
-            <button
-              onClick={onBackArrowClick}
-              type="button"
-              aria-label="Find another name"
-              className="flex items-center gap-6"
-            >
-              <Icon name="backArrow" color="currentColor" height="1rem" width="1rem" />
-              <p className="text-gray-50">EXTEND REGISTRATION</p>
-            </button>
-          </div>
+          <p className="absolute left-1/2 z-9 mx-auto w-full -translate-x-1/2 -translate-y-20 text-center text-gray-50 transition-opacity">
+            EXTEND REGISTRATION
+          </p>
           {/* The pill */}
           <Transition
             appear
@@ -98,7 +83,10 @@ export function RenewalFlow({ name }: RenewalFlowProps) {
             enterFrom="max-w-0"
             enterTo="max-w-full"
           >
-            <UsernamePill variant={currentUsernamePillVariant} username={name as Basename} />
+            <UsernamePill
+              variant={currentUsernamePillVariant}
+              username={formatBaseEthDomain(name, basenameChain.id)}
+            />
           </Transition>
         </Transition>
 

--- a/apps/web/src/components/Basenames/RenewalFlow.tsx
+++ b/apps/web/src/components/Basenames/RenewalFlow.tsx
@@ -1,0 +1,120 @@
+'use client';
+import dynamic from 'next/dynamic';
+import { Transition } from '@headlessui/react';
+import RegistrationBackground from 'apps/web/src/components/Basenames/RegistrationBackground';
+import RenewalForm from 'apps/web/src/components/Basenames/RenewalForm';
+import { UsernamePill } from 'apps/web/src/components/Basenames/UsernamePill';
+import { UsernamePillVariants } from 'apps/web/src/components/Basenames/UsernamePill/types';
+import useBasenameChain, { supportedChainIds } from 'apps/web/src/hooks/useBasenameChain';
+import classNames from 'classnames';
+import { useCallback, useEffect, useMemo } from 'react';
+import { useAccount, useSwitchChain } from 'wagmi';
+import { isDevelopment } from 'libs/base-ui/constants';
+import { Basename } from '@coinbase/onchainkit/identity';
+
+const RegistrationStateSwitcherDynamic = dynamic(
+  async () => import('apps/web/src/components/Basenames/RegistrationStateSwitcher'),
+  { ssr: false },
+);
+
+type RenewalFlowProps = {
+  name: string;
+};
+
+export function RenewalFlow({ name }: RenewalFlowProps) {
+  const { chain } = useAccount();
+  const { basenameChain } = useBasenameChain();
+  const { switchChain } = useSwitchChain();
+
+  const isOnSupportedNetwork = useMemo(
+    () => chain && supportedChainIds.includes(chain.id),
+    [chain],
+  );
+
+  const switchToIntendedNetwork = useCallback(
+    () => switchChain({ chainId: basenameChain.id }),
+    [basenameChain.id, switchChain],
+  );
+
+  useEffect(() => {
+    if (!chain || !switchToIntendedNetwork) {
+      return;
+    }
+
+    if (!isOnSupportedNetwork) {
+      switchToIntendedNetwork();
+    }
+  }, [isOnSupportedNetwork, chain, switchToIntendedNetwork]);
+
+  const layoutPadding = 'px-4 md:px-8';
+  const renewalTransitionDuration = 'duration-700';
+
+  const mainClasses = classNames(
+    'w-full relative min-h-screen pb-40',
+    'transition-[padding]',
+    layoutPadding,
+    renewalTransitionDuration,
+    'pt-[calc(35vh)] md:pt-[calc(50vh)]',
+  );
+
+  const currentUsernamePillVariant = UsernamePillVariants.Inline;
+
+  return (
+    <>
+      {true && isDevelopment && <RegistrationStateSwitcherDynamic />}
+      <section className={mainClasses}>
+        {/* Username Pill */}
+        <div className="relative flex w-full max-w-full flex-col items-center justify-center md:-translate-y-12">
+          <Transition
+            appear
+            show
+            className={classNames(
+              'relative z-10 w-full max-w-full transition-opacity',
+              renewalTransitionDuration,
+            )}
+            enterFrom="opacity-0"
+            enterTo="opacity-100"
+            leaveFrom="opacity-100"
+            leaveTo="opacity-0"
+          >
+            {/* The pill */}
+            <Transition
+              appear
+              show
+              className={classNames(
+                'transition-[max-width, transform] mx-auto',
+                renewalTransitionDuration,
+              )}
+              enterFrom="max-w-0"
+              enterTo="max-w-full"
+            >
+              <UsernamePill variant={currentUsernamePillVariant} username={name as Basename} />
+            </Transition>
+          </Transition>
+
+          {/* Renewal Form */}
+          <Transition
+            appear
+            show
+            className={classNames(
+              'relative z-40 transition-opacity',
+              'mx-auto',
+              renewalTransitionDuration,
+            )}
+            enterFrom="opacity-0"
+            enterTo="opacity-100"
+            leaveFrom="opacity-100"
+            leaveTo="opacity-0"
+          >
+            <RenewalForm name={name} />
+          </Transition>
+        </div>
+
+        {/* Animated background for each step */}
+        <RegistrationBackground />
+      </section>
+    </>
+  );
+}
+
+export default RenewalFlow;

--- a/apps/web/src/components/Basenames/RenewalForm/RenewalButton.tsx
+++ b/apps/web/src/components/Basenames/RenewalForm/RenewalButton.tsx
@@ -1,0 +1,50 @@
+import classNames from 'classnames';
+import { ConnectWallet } from '@coinbase/onchainkit/wallet';
+import { Button, ButtonSizes, ButtonVariants } from 'apps/web/src/components/Button/Button';
+import { useAccount } from 'wagmi';
+
+type RenewalButtonProps = {
+  correctChain: boolean;
+  renewNameCallback: () => void;
+  switchToIntendedNetwork: () => void;
+  disabled: boolean;
+  isLoading: boolean;
+};
+
+export function RenewalButton({
+  correctChain,
+  renewNameCallback,
+  switchToIntendedNetwork,
+  disabled,
+  isLoading,
+}: RenewalButtonProps) {
+  const { isConnected } = useAccount();
+
+  if (!isConnected) {
+    return (
+      <ConnectWallet
+        className={classNames(
+          'bg-button-black text-white hover:bg-button-blackHover active:bg-button-blackActive',
+          'px-10 py-3.5 text-sm md:text-lg',
+          'rounded-full',
+        )}
+        disconnectedLabel="Connect wallet"
+      />
+    );
+  }
+
+  return (
+    <Button
+      onClick={correctChain ? renewNameCallback : switchToIntendedNetwork}
+      type="button"
+      variant={ButtonVariants.Black}
+      size={ButtonSizes.Medium}
+      disabled={disabled || isLoading}
+      isLoading={isLoading}
+      rounded
+      fullWidth
+    >
+      {correctChain ? 'Extend registration' : 'Switch to Base'}
+    </Button>
+  );
+}

--- a/apps/web/src/components/Basenames/RenewalForm/index.tsx
+++ b/apps/web/src/components/Basenames/RenewalForm/index.tsx
@@ -13,12 +13,11 @@ import { ActionType } from 'libs/base-ui/utils/logEvent';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useAccount, useBalance, useSwitchChain } from 'wagmi';
 import { RenewalButton } from './RenewalButton';
-import {
-  formatEtherPrice,
-  formatUsdPrice,
-} from 'apps/web/src/components/Basenames/RegistrationForm';
+import { formatUsdPrice } from 'apps/web/src/utils/formatUsdPrice';
+import { formatEtherPrice } from 'apps/web/src/utils/formatEtherPrice';
 import { useNameList } from 'apps/web/src/components/Basenames/ManageNames/hooks';
 import YearSelector from 'apps/web/src/components/Basenames/YearSelector';
+import { formatBaseEthDomain } from 'apps/web/src/utils/usernames';
 
 export default function RenewalForm({ name }: { name: string }) {
   const { chain: connectedChain, address } = useAccount();
@@ -41,8 +40,8 @@ export default function RenewalForm({ name }: { name: string }) {
   );
 
   const nameData = useMemo(() => {
-    return namesData?.data.find((n) => n.domain === name);
-  }, [name, namesData?.data]);
+    return namesData?.data.find((n) => n.domain === formatBaseEthDomain(name, basenameChain.id));
+  }, [basenameChain.id, name, namesData?.data]);
 
   const formattedExpirationDate = useMemo(() => {
     if (!nameData?.expires_at) return undefined;
@@ -61,7 +60,7 @@ export default function RenewalForm({ name }: { name: string }) {
     renewNameStatus,
     batchCallsStatus,
   } = useRenewNameCallback({
-    name: name.replace(/\.base\.eth$/, ''),
+    name,
     years,
   });
 
@@ -121,7 +120,7 @@ export default function RenewalForm({ name }: { name: string }) {
     }
   }, [renewNameStatus, batchCallsStatus, refetch, logError]);
 
-  if (!isOnSupportedNetwork) {
+  if (address && !isOnSupportedNetwork) {
     return (
       <button
         type="button"

--- a/apps/web/src/components/Basenames/RenewalForm/index.tsx
+++ b/apps/web/src/components/Basenames/RenewalForm/index.tsx
@@ -109,7 +109,6 @@ export default function RenewalForm({ name }: { name: string }) {
     'z-10 flex flex-col items-start justify-between gap-6 bg-[#F7F7F7] p-8 text-gray-60 shadow-xl md:flex-row md:items-center relative z-20 rounded-2xl',
   );
 
-  // Handle successful renewal
   useEffect(() => {
     if (
       renewNameStatus === WriteTransactionWithReceiptStatus.Success ||

--- a/apps/web/src/components/Basenames/RenewalForm/index.tsx
+++ b/apps/web/src/components/Basenames/RenewalForm/index.tsx
@@ -116,9 +116,11 @@ export default function RenewalForm({ name }: { name: string }) {
       batchCallsStatus === BatchCallsStatus.Success
     ) {
       setYears(1);
-      refetch();
+      refetch().catch((e) => {
+        logError(e, 'Failed to refetch names');
+      });
     }
-  }, [renewNameStatus, batchCallsStatus]);
+  }, [renewNameStatus, batchCallsStatus, refetch, logError]);
 
   if (!isOnSupportedNetwork) {
     return (

--- a/apps/web/src/components/Basenames/RenewalForm/index.tsx
+++ b/apps/web/src/components/Basenames/RenewalForm/index.tsx
@@ -28,7 +28,7 @@ export default function RenewalForm({ name }: { name: string }) {
   const { logError } = useErrors();
   const { basenameChain } = useBasenameChain();
   const { switchChain } = useSwitchChain();
-  const { namesData } = useNameList();
+  const { namesData, isLoading, refetch } = useNameList();
 
   const switchToIntendedNetwork = useCallback(
     () => switchChain({ chainId: basenameChain.id }),
@@ -75,7 +75,6 @@ export default function RenewalForm({ name }: { name: string }) {
 
   const ethUsdPrice = useEthPriceFromUniswap();
 
-  // Implement the actual renewal function
   const renewName = useCallback(async () => {
     try {
       logEventWithContext('renew_name_initiated', ActionType.click);
@@ -116,8 +115,8 @@ export default function RenewalForm({ name }: { name: string }) {
       renewNameStatus === WriteTransactionWithReceiptStatus.Success ||
       batchCallsStatus === BatchCallsStatus.Success
     ) {
-      // TODO: Add success handling (redirect, show success message, etc.)
-      console.log('Renewal successful!');
+      setYears(1);
+      refetch();
     }
   }, [renewNameStatus, batchCallsStatus]);
 
@@ -174,7 +173,7 @@ export default function RenewalForm({ name }: { name: string }) {
             renewNameCallback={renewNameCallback}
             switchToIntendedNetwork={switchToIntendedNetwork}
             disabled={!price || insufficientFundsNoAuxFundsAndCorrectChain}
-            isLoading={isPending}
+            isLoading={isPending || isLoading}
           />
           {formattedExpirationDate && (
             <p className="text-md text-gray-50">Expires {formattedExpirationDate}</p>

--- a/apps/web/src/components/Basenames/RenewalForm/index.tsx
+++ b/apps/web/src/components/Basenames/RenewalForm/index.tsx
@@ -1,4 +1,4 @@
-import { ExclamationCircleIcon, MinusIcon, PlusIcon } from '@heroicons/react/16/solid';
+import { ExclamationCircleIcon } from '@heroicons/react/16/solid';
 import { useAnalytics } from 'apps/web/contexts/Analytics';
 import { useErrors } from 'apps/web/contexts/Errors';
 import { Icon } from 'apps/web/src/components/Icon/Icon';
@@ -18,6 +18,7 @@ import {
   formatUsdPrice,
 } from 'apps/web/src/components/Basenames/RegistrationForm';
 import { useNameList } from 'apps/web/src/components/Basenames/ManageNames/hooks';
+import YearSelector from 'apps/web/src/components/Basenames/YearSelector';
 
 export default function RenewalForm({ name }: { name: string }) {
   const { chain: connectedChain, address } = useAccount();
@@ -136,31 +137,12 @@ export default function RenewalForm({ name }: { name: string }) {
   return (
     <div className="mt-20 transition-all duration-500">
       <div className={mainRenewalElementClasses}>
-        <div className="max-w-[14rem] self-start">
-          <p className="text-line mb-2 text-sm font-bold uppercase">Extend for</p>
-          <div className="flex items-center justify-between">
-            <button
-              type="button"
-              onClick={decrement}
-              disabled={years === 1}
-              className="flex h-7 w-7 items-center justify-center rounded-full bg-[#DEE1E7]"
-              aria-label="Decrement years"
-            >
-              <MinusIcon width="14" height="14" className="fill-[#32353D]" />
-            </button>
-            <span className="flex w-32 items-center justify-center text-3xl font-bold text-black">
-              {years} year{years > 1 && 's'}
-            </span>
-            <button
-              type="button"
-              onClick={increment}
-              className="flex h-7 w-7 items-center justify-center rounded-full bg-[#DEE1E7]"
-              aria-label="Increment years"
-            >
-              <PlusIcon width="14" height="14" className="fill-[#32353D]" />
-            </button>
-          </div>
-        </div>
+        <YearSelector
+          years={years}
+          onIncrement={increment}
+          onDecrement={decrement}
+          label="Extend for"
+        />
         <div className="min-w-[14rem] self-start text-left">
           <p className="text-line mb-2 text-sm font-bold uppercase">Amount</p>
           <div className="flex min-w-60 items-center justify-start gap-4">

--- a/apps/web/src/components/Basenames/RenewalForm/index.tsx
+++ b/apps/web/src/components/Basenames/RenewalForm/index.tsx
@@ -61,7 +61,7 @@ export default function RenewalForm({ name }: { name: string }) {
     renewNameStatus,
     batchCallsStatus,
   } = useRenewNameCallback({
-    name,
+    name: name.replace(/\.base\.eth$/, ''),
     years,
   });
 

--- a/apps/web/src/components/Basenames/YearSelector/index.tsx
+++ b/apps/web/src/components/Basenames/YearSelector/index.tsx
@@ -1,0 +1,43 @@
+import { MinusIcon, PlusIcon } from '@heroicons/react/16/solid';
+
+type YearSelectorProps = {
+  years: number;
+  onIncrement: () => void;
+  onDecrement: () => void;
+  label: string;
+};
+
+export default function YearSelector({
+  years,
+  onIncrement,
+  onDecrement,
+  label,
+}: YearSelectorProps) {
+  return (
+    <div className="max-w-[14rem] self-start">
+      <p className="text-line mb-2 text-sm font-bold uppercase">{label}</p>
+      <div className="flex items-center justify-between">
+        <button
+          type="button"
+          onClick={onDecrement}
+          disabled={years === 1}
+          className="flex h-7 w-7 items-center justify-center rounded-full bg-[#DEE1E7]"
+          aria-label="Decrement years"
+        >
+          <MinusIcon width="14" height="14" className="fill-[#32353D]" />
+        </button>
+        <span className="flex w-32 items-center justify-center text-3xl font-bold text-black">
+          {years} year{years > 1 && 's'}
+        </span>
+        <button
+          type="button"
+          onClick={onIncrement}
+          className="flex h-7 w-7 items-center justify-center rounded-full bg-[#DEE1E7]"
+          aria-label="Increment years"
+        >
+          <PlusIcon width="14" height="14" className="fill-[#32353D]" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/utils/formatEtherPrice.ts
+++ b/apps/web/src/utils/formatEtherPrice.ts
@@ -1,0 +1,13 @@
+import { formatEther } from 'viem';
+
+export function formatEtherPrice(price?: bigint) {
+  if (price === undefined) {
+    return '...';
+  }
+  const value = parseFloat(formatEther(price));
+  if (value < 0.001) {
+    return parseFloat(value.toFixed(4));
+  } else {
+    return parseFloat(value.toFixed(3));
+  }
+}

--- a/apps/web/src/utils/formatUsdPrice.ts
+++ b/apps/web/src/utils/formatUsdPrice.ts
@@ -1,0 +1,8 @@
+import { formatEther } from 'viem';
+
+export function formatUsdPrice(price: bigint, ethUsdPrice: number) {
+  if (price === 0n) return '0';
+  const parsed = (parseFloat(formatEther(price)) * Number(ethUsdPrice)).toFixed(2);
+  if (parsed === '0.00') return '0';
+  return parsed;
+}


### PR DESCRIPTION
**What changed? Why?**

- Added a new page for renewing Basenames
  - This page is heavily inspired by the existing Basename registration flow. Some code has been abstracted and re-used
  - In upcoming PRs, this page will be navigated to from various entry points, and the existing renewal modal will be removed

**Notes to reviewers**

**How has it been tested?**

- Manually


https://github.com/user-attachments/assets/9cfe4ad7-b988-4976-a01a-ca36cc93884c


Have you tested the following pages?

BaseWeb
- [x] base.org
- [x] base.org/names
- [x] base.org/builders
- [x] base.org/ecosystem
- [x] base.org/name/jesse
- [x] base.org/manage-names
- [x] base.org/resources

BaseDocs

- [x] docs.base.org
- [x] docs sub-pages
