### PR TITLE
Docs: Node provider: Validation Cloud, adding Sepolia testnet support and full archive

### DIFF
--- a/apps/base-docs/docs/pages/chain/node-providers.mdx
+++ b/apps/base-docs/docs/pages/chain/node-providers.mdx
@@ -191,7 +191,7 @@ description: Documentation for Node Providers for the Base network. Including de
 
 ## Validation Cloud
 
-[Validation Cloud](https://app.validationcloud.io/) is the world’s fastest node provider according to Compare Nodes. With 50 million compute units available for use without a credit card and a scale tier that never has rate limits, Validation Cloud is built to support your most rigorous and low-latency workloads. Our nodes support Flashblocks and also provide full archive history for Base.
+[Validation Cloud](https://www.validationcloud.io/base) is the world’s fastest node provider according to Compare Nodes. With 50 million compute units available for use without a credit card and a scale tier that never has rate limits, Validation Cloud is built to support your most rigorous and low-latency workloads. Our nodes support Flashblocks and also provide full archive history for Base.
 
 #### Supported Networks
 


### PR DESCRIPTION
**What changed? Why?**

Docs change on the Node Providers page.

- Validation Cloud (Node Provider for Base) added support for Sepolia Testnet, in addition to the existing support for Base Mainnet. We also now support full archive history so Base developers get a complete experience.

I updated the Node Provider page to reflect this change.

**How has it been tested?**

Forked repo, made change, built and ran locally and confirmed all looked ok.
