### PR TITLE
[BA-2007] Check for failing frames and filter based on failure state

### DIFF
--- a/apps/web/src/components/Basenames/UsernameProfileSectionFrames/Frame.tsx
+++ b/apps/web/src/components/Basenames/UsernameProfileSectionFrames/Frame.tsx
@@ -211,12 +211,7 @@ export default function Frame({ url, className, onError }: FrameProps) {
     [className],
   );
 
-  // Now place the conditional returns AFTER all hooks
-  if (frameLoadError) {
-    return null;
-  }
-
-  if (!frameState) {
+  if (frameLoadError || !frameState) {
     return null;
   }
 

--- a/apps/web/src/components/Basenames/UsernameProfileSectionFrames/Frame.tsx
+++ b/apps/web/src/components/Basenames/UsernameProfileSectionFrames/Frame.tsx
@@ -37,6 +37,20 @@ type TransactionData = {
   };
 };
 
+// Define the types we actually use
+type FrameStackItem = {
+  status: string;
+  frameResult?: {
+    status?: string;
+    frame?: unknown;
+    specification?: string;
+  } | null;
+};
+
+type FrameState = {
+  currentFrameStackItem?: FrameStackItem | null;
+};
+
 export default function Frame({ url, className, onError }: FrameProps) {
   const { frameConfig: sharedConfig, farcasterSignerState, anonSignerState } = useFrameContext();
   const queryClient = useQueryClient();
@@ -135,8 +149,8 @@ export default function Frame({ url, className, onError }: FrameProps) {
   // Persist if openFrameWorks has ever been true for this frame
   const [openFrameWorksPersisted, setOpenFrameWorksPersisted] = useState(false);
 
-  // Add helper function to check if frame failed to load
-  const isFrameLoadError = useCallback((frameState: any) => {
+  // Add helper function to check if frame failed to load with proper typing
+  const isFrameLoadError = useCallback((frameState: FrameState) => {
     const currentItem = frameState.currentFrameStackItem;
     if (!currentItem) return false;
 

--- a/apps/web/src/components/Basenames/UsernameProfileSectionFrames/Frame.tsx
+++ b/apps/web/src/components/Basenames/UsernameProfileSectionFrames/Frame.tsx
@@ -37,7 +37,7 @@ type TransactionData = {
   };
 };
 
-// Define the types we actually use
+// Define the Frame types we actually use
 type FrameStackItem = {
   status: string;
   frameResult?: {
@@ -194,13 +194,10 @@ export default function Frame({ url, className, onError }: FrameProps) {
     }
   }, [openFrameState, openFrameWorksPersisted]);
 
-  const frameState = useMemo(() => {
-    if (openFrameWorksPersisted) {
-      return openFrameState;
-    } else {
-      return farcasterFrameState;
-    }
-  }, [farcasterFrameState, openFrameState, openFrameWorksPersisted]);
+  const frameState = useMemo(
+    () => (openFrameWorksPersisted ? openFrameState : farcasterFrameState),
+    [farcasterFrameState, openFrameState, openFrameWorksPersisted],
+  );
 
   // Move aggregatedTheme BEFORE the early returns
   const aggregatedTheme = useMemo(

--- a/apps/web/src/components/Basenames/UsernameProfileSectionFrames/FrameListItem.tsx
+++ b/apps/web/src/components/Basenames/UsernameProfileSectionFrames/FrameListItem.tsx
@@ -18,6 +18,7 @@ export default function FrameListItem({ url }: { url: string }) {
   const { currentWalletIsProfileOwner } = useUsernameProfile();
   const { logEventWithContext } = useAnalytics();
   const [isCopied, setIsCopied] = useState(false);
+  const [frameHasError, setFrameHasError] = useState(false);
 
   const [, copy] = useCopyToClipboard();
   const handleCopyFrameURLClick = useCallback(() => {
@@ -42,6 +43,11 @@ export default function FrameListItem({ url }: { url: string }) {
         logEventWithContext('basename_profile_frame_removed', ActionType.click, { context: url });
       });
   }, [logEventWithContext, removeFrame, url]);
+
+  // Don't render the entire FrameListItem if the frame has an error
+  if (frameHasError) {
+    return null;
+  }
 
   return (
     <div className="relative mb-4 break-inside-avoid">
@@ -93,7 +99,7 @@ export default function FrameListItem({ url }: { url: string }) {
           </Popover.Content>
         </Popover.Portal>
       </Popover.Root>
-      <Frame url={url} />
+      <Frame url={url} onError={setFrameHasError} />
     </div>
   );
 }


### PR DESCRIPTION
**What changed? Why?**

Frames are failing to render. Broadly, frames are deprecated, specifically Frames v1. We want to move to mini-app support, but in the meantime should make sure that failing frames do not render on the profile page. 

Before:
![Screenshot 2025-05-29 at 11 58 34 AM](https://github.com/user-attachments/assets/8b42d0dc-0e0a-4ee3-9799-ee24e356ee4c)

With fix: 
![Screenshot 2025-05-29 at 11 59 25 AM](https://github.com/user-attachments/assets/a82b4345-36c0-49b4-b8be-ff81ea681d69)

**Notes to reviewers**

**How has it been tested?**

Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources

BaseDocs
- [] docs.base.org
- [] docs sub-pages
