### PR TITLE
fix: typo in machine type

### DIFF
--- a/apps/base-docs/docs/pages/chain/node-performance.mdx
+++ b/apps/base-docs/docs/pages/chain/node-performance.mdx
@@ -34,7 +34,7 @@ The following are the hardware specifications used for Base production nodes:
   - Storage: RAID 0 of all local NVMe drives (`/dev/nvme*`)
   - Filesystem: ext4
 - **Reth Archive Node:**
-  - Instance: AWS `i4ie.6xlarge`
+  - Instance: AWS `i7ie.6xlarge`
   - Storage: RAID 0 of all local NVMe drives (`/dev/nvme*`)
   - Filesystem: ext4
 


### PR DESCRIPTION
**What changed? Why?**
Fix instance type typo

