### PR TITLE
chore: remove redundant null check

### DIFF
--- a/apps/web/src/components/Basenames/UsernameProfileSectionFrames/Frame.tsx
+++ b/apps/web/src/components/Basenames/UsernameProfileSectionFrames/Frame.tsx
@@ -55,7 +55,6 @@ export default function Frame({ url, className, onError }: FrameProps) {
   const { frameConfig: sharedConfig, farcasterSignerState, anonSignerState } = useFrameContext();
   const queryClient = useQueryClient();
   const [error, setError] = useState<string>('');
-  const [frameLoadError, setFrameLoadError] = useState<boolean>(false);
   const clearError = useCallback(() => setError(''), []);
   const [isDismissing, setIsDismissing] = useState<boolean>(false);
   const handleDismissError = useCallback(() => {
@@ -169,7 +168,6 @@ export default function Frame({ url, className, onError }: FrameProps) {
 
     // If both frame types fail, mark as failed
     const hasError = farcasterFailed && openFrameFailed;
-    setFrameLoadError(hasError);
 
     // Notify parent component of error state
     onError?.(hasError);
@@ -210,10 +208,6 @@ export default function Frame({ url, className, onError }: FrameProps) {
     }),
     [className],
   );
-
-  if (frameLoadError || !frameState) {
-    return null;
-  }
 
   return (
     <div className="relative">


### PR DESCRIPTION
**What changed? Why?**
* removed redundant null check from `Frame` — error state handled by the UI parent, `FrameListItem`

**Notes to reviewers**
* there should be no change to behavior, this is a code simplification

**How has it been tested?**

Have you tested the following pages?

BaseWeb
- [x] base.org
- [x] base.org/names
- [x] base.org/builders
- [x] base.org/ecosystem
- [x] base.org/name/jesse
- [x] base.org/manage-names
- [x] base.org/resources

BaseDocs
- [x] docs.base.org
- [x] docs sub-pages
