### PR TITLE
Patch to remove advanced use cases from profiles guide

### DIFF
--- a/apps/base-docs/docs/pages/identity/smart-wallet/guides/profiles.mdx
+++ b/apps/base-docs/docs/pages/identity/smart-wallet/guides/profiles.mdx
@@ -566,46 +566,7 @@ ngrok http 3000
 
 5. Connect your Smart Wallet and test requesting and validating user data.
 
-## Advanced Use Cases
-
-### Combining with Transactions
-
-You can combine profile data requests with actual blockchain transactions:
-
-```ts
-const response = await provider?.request({
-  method: "wallet_sendCalls",
-  params: [
-    {
-      version: "1.0",
-      chainId: numberToHex(84532),
-      calls: [
-        {
-          to: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913", // USDC contract
-          data: encodeFunctionData({
-            abi: erc20Abi,
-            functionName: "transfer",
-            args: [
-              "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
-              parseUnits("0.01", 6),
-            ],
-          }),
-        },
-      ],
-      capabilities: {
-        dataCallback: {
-          requests: [{ type: "email", optional: false }],
-          callbackURL: getCallbackURL(),
-        },
-      },
-    },
-  ],
-});
-```
-
-This way, you can collect shipping information while processing a payment, or get an email for order confirmation while executing a transaction.
-
-### Making Fields Optional
+## Making Fields Optional
 
 You can make any requested field optional by setting the `optional` parameter:
 


### PR DESCRIPTION
**What changed? Why?**

A small patch to align with the profiles vision

BaseDocs
- [x] docs.base.org
- [x] docs sub-pages
