### PR TITLE
chore: update ipSafe blocklists

### DIFF
--- a/apps/web/src/middleware/ipSafe.ts
+++ b/apps/web/src/middleware/ipSafe.ts
@@ -1,5 +1,14 @@
 import ipaddr from 'ipaddr.js';
 
+const IPV4_BLOCKLIST = [
+  '0.0.0.0',
+  '169.254.169.254', // AWS metadata service
+];
+
+const IPV6_BLOCKLIST = [
+  'fd00:ec2::254', // AWS metadata service (IPv6)
+];
+
 export function ipSafe(ipStr: string): boolean {
   try {
     const ip = ipaddr.parse(ipStr);
@@ -26,6 +35,11 @@ export function ipSafe(ipStr: string): boolean {
 }
 
 function ipv4Safe(ip: ipaddr.IPv4): boolean {
+  // Reject special IPs like 0.0.0.0 and non-standard prefixes
+  if (IPV4_BLOCKLIST.includes(ip.toString())) {
+    return false;
+  }
+
   const range = ip.range();
 
   // Reject private, link-local, loopback, or broadcast IPs
@@ -33,15 +47,14 @@ function ipv4Safe(ip: ipaddr.IPv4): boolean {
     return false;
   }
 
-  // Reject special IPs like 0.0.0.0 and non-standard prefixes
-  if (ip.toString() === '0.0.0.0') {
-    return false;
-  }
-
   return true;
 }
 
 function ipv6Safe(ip: ipaddr.IPv6): boolean {
+  if (IPV6_BLOCKLIST.includes(ip.toString())) {
+    return false;
+  }
+
   // If IPv6 address is mapped to an IPv4 address, ensure it's safe
   if (ip.isIPv4MappedAddress()) {
     const ipv4 = ip.toIPv4Address();


### PR DESCRIPTION
**What changed? Why?**
* added IP addresses to `ipSafe`'s blocklists

**Notes to reviewers**
* cidr ranges handled by `ipaddr` range blocking

**How has it been tested?**

Have you tested the following pages?

BaseWeb
- [x] base.org
- [x] base.org/names
- [x] base.org/builders
- [x] base.org/ecosystem
- [x] base.org/name/jesse
- [x] base.org/manage-names
- [x] base.org/resources

BaseDocs
- [] docs.base.org
- [] docs sub-pages
