### PR TITLE
[docs]: update link to isbaseoptions

### DIFF
--- a/apps/base-docs/docs/pages/builderkits/onchainkit/config/is-base.mdx
+++ b/apps/base-docs/docs/pages/builderkits/onchainkit/config/is-base.mdx
@@ -32,5 +32,5 @@ false; // For all other chain IDs
 
 ## Parameters
 
-[`IsBaseOptions`](./types#isbaseoptions) - See [`IsBaseOptions`](./types#isbaseoptions) for more details.
+[`IsBaseOptions`](/builderkits/onchainkit/config/types#isbaseoptions) - See [`IsBaseOptions`](/builderkits/onchainkit/config/types#isbaseoptions) for more details.
 


### PR DESCRIPTION
**What changed? Why?**
there is nonworking link here - https://docs.base.org/builderkits/onchainkit/config/is-base
**Notes to reviewers**
The old link is made so that it works only in the github version of the docs. while on https://docs.base.org/builderkits/onchainkit/config/is-base it does not work. that's why I changed the link to https://docs.base.org/builderkits/onchainkit/config/types#isbaseoptions and after the release everything will work as it should.
**How has it been tested?**

Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources

BaseDocs
- [x] docs.base.org
- [] docs sub-pages
