### PR TITLE
chore: restore block building docs to sidebar

### DIFF
--- a/apps/base-docs/sidebar.ts
+++ b/apps/base-docs/sidebar.ts
@@ -1087,6 +1087,10 @@ export const sidebar: Sidebar = [
         link: '/chain/security-council',
       },
       {
+        text: 'Block Building',
+        link: '/chain/block-building',
+      },
+      {
         text: 'Tools',
         collapsed: true,
         items: [


### PR DESCRIPTION
**What changed? Why?**
Add block-building docs to the sidebar.

**How has it been tested?**
Dev
![Screenshot 2025-06-09 at 2 06 33 PM](https://github.com/user-attachments/assets/93bfa07b-3a23-4f39-bce5-0be01dd18e43)

Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources

BaseDocs
- [] docs.base.org
- [] docs sub-pages
