### PR TITLE
[BA-1968] Add re-useable banner component

### DIFF
--- a/apps/web/src/components/Banner/index.tsx
+++ b/apps/web/src/components/Banner/index.tsx
@@ -2,15 +2,22 @@ import Link from 'next/link';
 import { Icon } from 'apps/web/src/components/Icon/Icon';
 import { useState } from 'react';
 
-interface BannerProps {
+type BannerProps = {
   bgColor?: string;
   textColor?: string;
   message: string;
-  actionText: string;
-  actionUrl: string;
-}
+} & (
+  | {
+      actionText: string;
+      actionUrl: string;
+    }
+  | {
+      actionText?: never;
+      actionUrl?: never;
+    }
+);
 
-export function BannerWithCTA({
+export function Banner({
   bgColor = 'bg-yellow-20',
   textColor = 'text-black',
   message,
@@ -34,9 +41,11 @@ export function BannerWithCTA({
       >
         <span className="text-xs font-semibold md:text-base">{message}</span>
         <div className="flex flex-row items-center gap-4">
-          <Link href={actionUrl}>
-            <span className="text-xs font-semibold underline md:text-base">{actionText}</span>
-          </Link>
+          {actionText && actionUrl && (
+            <Link href={actionUrl}>
+              <span className="text-xs font-semibold underline md:text-base">{actionText}</span>
+            </Link>
+          )}
           <button
             className="cursor-pointer p-2 text-xs"
             type="button"

--- a/apps/web/src/components/BannerWithCTA/index.tsx
+++ b/apps/web/src/components/BannerWithCTA/index.tsx
@@ -3,15 +3,15 @@ import { Icon } from 'apps/web/src/components/Icon/Icon';
 import { useState } from 'react';
 
 interface BannerProps {
-  bgColor: string;
-  textColor: string;
+  bgColor?: string;
+  textColor?: string;
   message: string;
   actionText: string;
   actionUrl: string;
 }
 
 export function BannerWithCTA({
-  bgColor,
+  bgColor = 'bg-yellow-20',
   textColor = 'text-black',
   message,
   actionText,

--- a/apps/web/src/components/BannerWithCTA/index.tsx
+++ b/apps/web/src/components/BannerWithCTA/index.tsx
@@ -1,0 +1,52 @@
+import Link from 'next/link';
+import { Icon } from 'apps/web/src/components/Icon/Icon';
+import { useState } from 'react';
+
+interface BannerProps {
+  bgColor: string;
+  textColor: string;
+  message: string;
+  actionText: string;
+  actionUrl: string;
+}
+
+export function BannerWithCTA({
+  bgColor,
+  textColor = 'text-black',
+  message,
+  actionText,
+  actionUrl,
+}: BannerProps) {
+  const [isOpen, setIsOpen] = useState(true);
+
+  const handleClose = () => {
+    setIsOpen(false);
+  };
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div className={`flex w-full flex-row justify-center ${bgColor} ${textColor}`}>
+      <div
+        className={`flex w-full max-w-[1440px] flex-row items-center justify-between self-center ${bgColor} p-2 px-6`}
+      >
+        <span className="text-xs font-semibold md:text-base">{message}</span>
+        <div className="flex flex-row items-center gap-4">
+          <Link href={actionUrl}>
+            <span className="text-xs font-semibold underline md:text-base">{actionText}</span>
+          </Link>
+          <button
+            className="cursor-pointer p-2 text-xs"
+            type="button"
+            aria-label="Close banner"
+            onClick={handleClose}
+          >
+            <Icon name="close" color="black" width="16" height="16" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
**What changed? Why?**

- Added a re-useable banner component. This component will be used to remind users of their Basename expiring, and provide them with a CTA to renew. 
  - Next PR will implement the logic for showing this banner

**Notes to reviewers**

**How has it been tested?**

- Manually 



https://github.com/user-attachments/assets/d8870f08-a005-4a4e-adc2-a7c846ebf59c

(rendered it just for the demo)


Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources
