### PR TITLE
[bug] Use ENV config CDP uri for manage-names route 

### DIFF
--- a/apps/web/app/(basenames)/api/basenames/getUsernames/route.ts
+++ b/apps/web/app/(basenames)/api/basenames/getUsernames/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 import type { ManagedAddressesResponse } from 'apps/web/src/types/ManagedAddresses';
+import { cdpBaseUri } from 'apps/web/src/cdp/constants';
 
 export async function GET(request: NextRequest) {
   const address = request.nextUrl.searchParams.get('address');
@@ -14,7 +15,7 @@ export async function GET(request: NextRequest) {
   }
 
   const response = await fetch(
-    `https://api.cdp.coinbase.com/platform/v1/networks/${network}/addresses/${address}/identity?limit=50`,
+    `https://${cdpBaseUri}/platform/v1/networks/${network}/addresses/${address}/identity?limit=50`,
     {
       headers: {
         Authorization: `Bearer ${process.env.CDP_BEARER_TOKEN}`,


### PR DESCRIPTION
**What changed? Why?**
Previously, we used a hardcoded prod-specific endpoint for manage-names. We should use the env-provided cdp URI so that the manage-names page works on dev. 

**Notes to reviewers**

**How has it been tested?**
Tested by setting local env to dev's config w/ cbhq endpoints/tokens/secrets. 

Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources
