### PR TITLE
[wert.io]: update url

### DIFF
--- a/apps/web/src/data/ecosystem/wert/metadata.json
+++ b/apps/web/src/data/ecosystem/wert/metadata.json
@@ -1,7 +1,7 @@
 {
   "name": "Wert",
   "description": "Fiat Onramp and NFT checkout. Users paying with a card can execute any smart contract function and receive tokens/nfts directly to their wallet in the same transaction. ",
-  "url": "wert.io",
+  "url": "https://wert.io/",
   "imageUrl": "/images/partners/wert.png",
   "category": "onramp",
   "subcategory": "fiat on-ramp"


### PR DESCRIPTION
**What changed? Why?**

changed url because previous one wasn't working correct on this page https://www.base.org/ecosystem .
![Zrzut ekranu 2025-06-28 141544](https://github.com/user-attachments/assets/101be237-0386-4365-a749-cd8782c38f6f)

and now it will work properly 
![image](https://github.com/user-attachments/assets/44f9dbe7-7df1-40f3-9b98-f4f81fb077b9)


**Notes to reviewers**

**How has it been tested?**

Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [x] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources
