### PR TITLE
remove broken nexandria url

### DIFF
--- a/apps/web/src/data/ecosystem/nexandria/metadata.json
+++ b/apps/web/src/data/ecosystem/nexandria/metadata.json
@@ -1,7 +1,7 @@
 {
   "name": "Nexandria",
   "description": "Nexandria helps solve the blockchain data access trilemma of speed, cost & completeness, enabling uniquely powerful API endpoints for DeFi, SocialFi, AI agents or Analytics.",
-  "url": "https://www.nexandria.com/",
+  "url": "",
   "imageUrl": "/images/partners/nexandria.png",
   "category": "infra",
   "subcategory": "developer tool"


### PR DESCRIPTION
Removing non-functional URL from metadata.json to maintain data integrity. Recommend keeping the field empty until the new URL is ready for production.
<img width="1082" alt="Знімок екрана 2025-07-01 о 20 49 40" src="https://github.com/user-attachments/assets/adb71580-c10c-48aa-920c-847d907877ce" />


