### PR TITLE
Update PolicyBanner.tsx

### DIFF
--- a/apps/web/src/components/Banner/PolicyBanner.tsx
+++ b/apps/web/src/components/Banner/PolicyBanner.tsx
@@ -40,7 +40,7 @@ export function PolicyBanner() {
             updated policy.
           </div>
           <button
-            className="text-md text-md transition-allactive:bg-[#06318E] flex w-auto items-center justify-center gap-3 whitespace-nowrap rounded-lg border px-4 py-2 text-black disabled:pointer-events-none disabled:opacity-40 dark:text-white"
+            className="text-md text-md transition-all active:bg-[#06318E] flex w-auto items-center justify-center gap-3 whitespace-nowrap rounded-lg border px-4 py-2 text-black disabled:pointer-events-none disabled:opacity-40 dark:text-white"
             type="button"
             onClick={onDismiss}
           >


### PR DESCRIPTION
Fix: Missing space in Tailwind class for active state

This PR fixes a small but important typo in `PolicyBanner.tsx`.

### What was fixed

In this line:
```tsx
className="text-md text-md transition-allactive:bg-[#06318E] ..."

There was a missing space between transition-all and active:bg-[#06318E]. This prevented the active: state from working properly.

Fixed version:

className="text-md text-md transition-all active:bg-[#06318E] ..."

**What changed? Why?**

**Notes to reviewers**

**How has it been tested?**

Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources
