### PR TITLE
chore: Update ramp.network to rampnetwork.com

### DIFF
--- a/apps/base-docs/docs/tools/onramps.md
+++ b/apps/base-docs/docs/tools/onramps.md
@@ -47,7 +47,7 @@ hide_table_of_contents: true
 
 ## Ramp
 
-[Ramp](https://ramp.network/) is an onramp and offramp that empowers users to buy & sell crypto inside your app. Ramp supports 40+ fiat currencies and 90+ crypto assets, including ETH on Base.
+[Ramp](https://rampnetwork.com/) is an onramp and offramp that empowers users to buy & sell crypto inside your app. Ramp supports 40+ fiat currencies and 90+ crypto assets, including ETH on Base.
 
 ---
 

--- a/apps/web/src/data/ecosystem.json
+++ b/apps/web/src/data/ecosystem.json
@@ -1217,7 +1217,7 @@
   },
   {
     "name": "Ramp Network",
-    "url": "https://ramp.network",
+    "url": "https://rampnetwork.com",
     "description": "Empower users to buy & sell crypto inside your app.",
     "imageUrl": "/images/partners/ramp.webp",
     "category": "onramp",


### PR DESCRIPTION
**What changed? Why?**

**Notes to reviewers**

**How has it been tested?**

Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources
