### PR TITLE
Update Brand Kit link in footer to point to base.org/brand

### DIFF
--- a/apps/web/src/components/Layout/Footer/Footer.tsx
+++ b/apps/web/src/components/Layout/Footer/Footer.tsx
@@ -32,7 +32,7 @@ const LINK_SECTIONS = [
     title: 'Resources',
     links: [
       { label: 'Grants', href: 'https://paragraph.xyz/@grants.base.eth/calling-based-builders' },
-      { label: 'Brand kit', href: 'https://github.com/base/brand-kit' },
+      { label: 'Brand kit', href: 'https://www.base.org/brand' },
       { label: 'Events', href: 'https://lu.ma/BaseMeetups' },
     ],
   },


### PR DESCRIPTION
**What changed? Why?**

This PR updates the Brand Kit link in the footer from https://github.com/base/brand-kit to https://www.base.org/brand to point to the new brand guidelines page.

**Notes to reviewers**

**How has it been tested?**

Locally

Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources
