### PR TITLE
fix: add missing dependencies to useMemo in AsciiFluidSceneBuilders

### DIFF
--- a/apps/web/app/(base-org-dark)/(builders)/AsciiFluidSceneBuilders.tsx
+++ b/apps/web/app/(base-org-dark)/(builders)/AsciiFluidSceneBuilders.tsx
@@ -77,7 +77,7 @@ export default function AsciiFluidSceneBuilders({
       uDarkMode: new THREE.Uniform(darkMode),
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [interactionUniforms]);
+  }, [interactionUniforms, fbo.texture, darkMode]);
 
   const handleResize = useCallback(
     (width: number, height: number) => {


### PR DESCRIPTION
Add missing dependencies (fbo.texture, darkMode) to useMemo hook in AsciiFluidSceneBuilders component to ensure customUniforms updates correctly when these values change.