### PR TITLE
chore: fixes for onchainkit demo

### DIFF
--- a/apps/web/src/components/Builders/Shared/LiveDemo/index.tsx
+++ b/apps/web/src/components/Builders/Shared/LiveDemo/index.tsx
@@ -89,6 +89,7 @@ export function LiveDemo({
     switch (activeTab) {
       case 'SmartWallet':
         return (
+          // TODO: upgrade to onchainkit v1 and remove this hacky solution
           <>
             <style>{`
               .ock-text-foreground {


### PR DESCRIPTION
**What changed? Why?**

- Adds in a very hacky solution to fix the styling issue for onchainkit demo
- The underlying cause is likely due to the specific onchainkit version we are using having issues with `findComponent`. However we can't upgrade onchainkit as of this version due to not wanting to break basenames
- Once onchainkit v1 is stable let's migrate over and remove this hacky solution

**Notes to reviewers**

**How has it been tested?**

Manually but the issue is mainly on prod


<img width="370" height="234" alt="Screenshot 2025-07-20 at 10 06 38 PM" src="https://github.com/user-attachments/assets/dbd785e8-7603-4352-a542-f965ebcc7725" />

Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources
