### PR TITLE
feat: handle /smart-wallet redirect

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -355,6 +355,11 @@ module.exports = MillionLint.next({
             permanent: true,
           },
           {
+            source: '/builders/smart-wallet',
+            destination: '/build/base-account',
+            permanent: true,
+          },
+          {
             source: '/builders/:path',
             destination: '/build/:path',
             permanent: true,


### PR DESCRIPTION
**What changed? Why?**

redirect /builders/smart-wallet to base account

**Notes to reviewers**

**How has it been tested?**

manually

Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources
