### PR TITLE
Feat: graceful grace period redirects

### DIFF
--- a/apps/web/src/utils/redirectIfNameDoesNotExist.ts
+++ b/apps/web/src/utils/redirectIfNameDoesNotExist.ts
@@ -27,7 +27,7 @@ export async function redirectIfNameDoesNotExist(username: Basename) {
   }
 
   // If API calls failed OR returned null/undefined values, the name doesn't exist or is expired
-  const nameNotFound = apiError || !address || !editor || !owner;
+  const nameNotFound = !address || !editor || !owner;
 
   if (nameNotFound) {
     logger.info('Basename not found, checking grace period', {

--- a/apps/web/src/utils/redirectIfNameDoesNotExist.ts
+++ b/apps/web/src/utils/redirectIfNameDoesNotExist.ts
@@ -3,6 +3,7 @@ import {
   getBasenameAddress,
   getBasenameEditor,
   getBasenameOwner,
+  isBasenameInGracePeriod,
 } from 'apps/web/src/utils/usernames';
 import { redirect } from 'next/navigation';
 
@@ -14,8 +15,14 @@ export async function redirectIfNameDoesNotExist(username: Basename) {
   ]).catch(() => {
     redirect(`/name/not-found?name=${username}`);
   });
+
   // Domain does not have address or editor (ie: doesn't exist)
   if (!address || !editor || !owner) {
-    redirect(`/name/not-found?name=${username}`);
+    // Before redirecting, check if the name is in grace period
+    // Names in grace period should be allowed to access renewal flow
+    const inGracePeriod = await isBasenameInGracePeriod(username);
+    if (!inGracePeriod) {
+      redirect(`/name/not-found?name=${username}`);
+    }
   }
 }

--- a/apps/web/src/utils/usernames.ts
+++ b/apps/web/src/utils/usernames.ts
@@ -797,6 +797,10 @@ export async function isBasenameInGracePeriod(username: Basename): Promise<boole
     // Name is in grace period if it's expired but within the grace period duration
     return timeSinceExpiration > 0 && timeSinceExpiration <= GRACE_PERIOD_DURATION_MS;
   } catch (error) {
+    logger.error('Error checking if basename is in grace period', {
+      error,
+      username,
+    });
     return false;
   }
 }

--- a/apps/web/src/utils/usernames.ts
+++ b/apps/web/src/utils/usernames.ts
@@ -769,3 +769,27 @@ export const REGISTER_CONTRACT_ADDRESSES = IS_EARLY_ACCESS
   : USERNAME_REGISTRAR_CONTROLLER_ADDRESSES;
 
 export const isBasenameRenewalsKilled = process.env.NEXT_PUBLIC_KILL_BASENAMES_RENEWALS === 'true';
+
+// Grace period duration in seconds (90 days)
+export const GRACE_PERIOD_DURATION_MS = 90 * 24 * 60 * 60 * 1000;
+
+/**
+ * Check if a basename is in its grace period (expired but still renewable)
+ */
+export async function isBasenameInGracePeriod(username: Basename): Promise<boolean> {
+  try {
+    const expiresAt = await getBasenameNameExpires(username);
+    if (!expiresAt) {
+      return false;
+    }
+
+    const expirationTime = Number(expiresAt) * 1000; // Convert to milliseconds
+    const currentTime = Date.now();
+    const timeSinceExpiration = currentTime - expirationTime;
+
+    // Name is in grace period if it's expired but within the grace period duration
+    return timeSinceExpiration > 0 && timeSinceExpiration <= GRACE_PERIOD_DURATION_MS;
+  } catch (error) {
+    return false;
+  }
+}

--- a/apps/web/src/utils/usernames.ts
+++ b/apps/web/src/utils/usernames.ts
@@ -633,7 +633,14 @@ export async function getBasenameNameExpires(username: Basename) {
     });
 
     return nameExpires;
-  } catch (error) {}
+  } catch (error) {
+    logger.error('Error fetching basename expiration date', {
+      error,
+      username,
+      tokenId,
+      chainId: chain.id,
+    });
+  }
 }
 
 export async function getBasenameAvailable(name: string, chain: Chain): Promise<boolean> {


### PR DESCRIPTION
**What changed? Why?**
Added handling for names in grace period so that they don't get redirected to the "name-not-found" page. 

**Notes to reviewers**

**How has it been tested?**

Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources
