### PR TITLE
feat: CO-179 fix footer link to go to proper brand site

### DIFF
--- a/apps/web/src/components/Layout/Navigation/navigation.ts
+++ b/apps/web/src/components/Layout/Navigation/navigation.ts
@@ -467,7 +467,7 @@ export const DEFAULT_ROUTES: DefaultRoute[] = [
       {
         icon: 'media',
         label: 'Brand Kit',
-        href: 'https://brand.base.org',
+        href: 'https://base.org/brand',
       },
     ],
   },


### PR DESCRIPTION
**What changed? Why?**

fix footer link
CO-179

**Notes to reviewers**

**How has it been tested?**

Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources
