### PR TITLE
fix: Fix document undefined error on profile page

### DIFF
--- a/apps/web/src/hooks/useBasenameExpirationBanner.tsx
+++ b/apps/web/src/hooks/useBasenameExpirationBanner.tsx
@@ -81,6 +81,9 @@ export function useBasenameExpirationBanner() {
   }, [msUntilExpiration, currentWalletIsProfileEditor]);
 
   const expirationBanner = useMemo(() => {
+    // Document may be undefined during SSR
+    if (typeof document === 'undefined') return null;
+
     const portalElement = document.getElementById('name-expiration-banner-portal');
     if (!portalElement || !expirationBannerConfig) return null;
 


### PR DESCRIPTION
**What changed? Why?**

- The following error would appear on the server when loading the profile page:
 
<img width="1073" height="244" alt="image" src="https://github.com/user-attachments/assets/067a646f-ff9a-4974-bf06-0ca0e302999d" />


- This PR fixes by checking if document is defined


**Notes to reviewers**

**How has it been tested?**

Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources
