### PR TITLE
chore: Add Metamask domains to CSP

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -65,6 +65,8 @@ const ccaLiteDomains = 'https://cca-lite.coinbase.com';
 const sprigDomains = 'https://api.sprig.com https://cdn.sprig.com';
 const walletconnectDomains =
   'https://*.walletconnect.org wss://*.walletconnect.org wss://*.walletconnect.com https://*.walletconnect.com https://explorer-api.walletconnect.com';
+const metamaskDomains =
+  'wss://metamask-sdk.api.cx.metamask.io https://metamask-sdk.api.cx.metamask.io';
 
 const contentSecurityPolicy = {
   'default-src': [
@@ -128,6 +130,8 @@ const contentSecurityPolicy = {
     'https://blue-api.morpho.org/graphql', // morpho
     'https://base-sepolia.easscan.org/graphql', // nft
     'https://*.google-analytics.com',
+    'wss://metamask-sdk.api.cx.metamask.io', // MetaMask SDK websocket
+    'https://metamask-sdk.api.cx.metamask.io', // MetaMask SDK API
   ],
   'frame-src': ['https://p.datadoghq.com', walletconnectDomains],
   'frame-ancestors': ["'self'", baseXYZDomains],


### PR DESCRIPTION
**What changed? Why?**

- Metamask domains were not apart of CSP, which caused it to not work when trying to connect. This PR adds the domains 

**Notes to reviewers**

**How has it been tested?**

- Manually


https://github.com/user-attachments/assets/6f965ab2-1922-4ee1-b033-4e3c7fad7cc6



Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources
