### PR TITLE
fix: Make nav bar more responsive on mobile

### DIFF
--- a/apps/web/src/components/Layout/UsernameNav/index.tsx
+++ b/apps/web/src/components/Layout/UsernameNav/index.tsx
@@ -40,12 +40,12 @@ export default function UsernameNav() {
     [switchChain],
   );
 
-  const walletStateClasses = classNames('p-2 rounded flex items-center gap-6', {
+  const walletStateClasses = classNames('p-2 rounded flex items-center gap-2 md:gap-6', {
     'bg-white': isConnected,
   });
 
   const navigationClasses = classNames(
-    'flex h-24 w-full max-w-[1440px] flex-row items-center justify-between gap-4 md:gap-16 self-center bg-transparent px-4 md:px-8',
+    'flex h-24 w-full max-w-[1440px] flex-row items-center justify-between gap-2 md:gap-4 lg:gap-16 self-center bg-transparent px-2 md:px-4 lg:px-8',
   );
 
   return (
@@ -112,7 +112,7 @@ export default function UsernameNav() {
             <span className="text-md text-palette-primary">
               <Link href="/manage-names" className="flex items-center gap-2">
                 <Icon name="list" color="currentColor" width="1rem" height="1rem" />
-                My Basenames
+                <span className="hidden sm:inline">My Basenames</span>
               </Link>
             </span>
           )}


### PR DESCRIPTION
**What changed? Why?**

- Updated base names nav bar styles to be more responsive on mobile. Modified some padding and made the "My Basenames" text hidden when the screen isn't wide enough

**Notes to reviewers**

**How has it been tested?**

<img width="454" height="897" alt="image" src="https://github.com/user-attachments/assets/89349fe4-2f93-431a-a259-6c35b03bd80a" />


Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources
