### PR TITLE
chore(tailwind): fix rgba typos in Update tailwind.config.js

### DIFF
--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -27,8 +27,8 @@ module.exports = {
       currentColor: 'currentColor',
       base: {
         white: 'rgba(255, 255, 255, 1)',
-        black: 'rgb(50, 50, 50, 1)',
-        blackInvert: 'rgb(205, 205, 205, 1)',
+        black: 'rgba(50, 50, 50, 1)',
+        blackInvert: 'rgba(205, 205, 205, 1)',
         gray: {
           10: 'rgb(238, 240, 243)',
           25: 'rgba(250, 250, 250, 1)',


### PR DESCRIPTION
Invalid CSS: rgb() was used with 4 arguments (rgb(50, 50, 50, 1) and rgb(205, 205, 205, 1)). In comma-separated syntax, rgb() accepts only 3 arguments—alpha must be specified via rgba() or the modern space/slash syntax (rgb(50 50 50 / 1)).

Why:
Browsers ignore invalid rgb(… , … , … , a) declarations, so any utility relying on base.black/base.blackInvert would silently fall back to previous/ inherited color.

How I tested:
Ran next build and verified Tailwind compiled without errors.

Confirmed generated CSS includes expected color values for utilities that reference base.black and base.blackInvert.

Notes:
No visual diffs included since this is a correctness fix; behavior is unchanged except that the colors now apply as intended.