### PR TITLE
[ENSIP 19] Update set primary flow for SCWs

### DIFF
--- a/apps/web/src/hooks/useSetPrimaryBasename.ts
+++ b/apps/web/src/hooks/useSetPrimaryBasename.ts
@@ -137,9 +137,9 @@ export default function useSetPrimaryBasename({ secondaryUsername }: UseSetPrima
 
   const isLoading =
     transactionIsLoading ||
+    batchCallsIsLoading ||
     primaryUsernameIsLoading ||
-    primaryUsernameIsFetching ||
-    batchCallsIsLoading;
+    primaryUsernameIsFetching;
 
   return {
     setPrimaryName,

--- a/apps/web/src/hooks/useSetPrimaryBasename.ts
+++ b/apps/web/src/hooks/useSetPrimaryBasename.ts
@@ -11,6 +11,9 @@ import useBaseEnsName from 'apps/web/src/hooks/useBaseEnsName';
 import { useErrors } from 'apps/web/contexts/Errors';
 import useWriteContractWithReceipt from 'apps/web/src/hooks/useWriteContractWithReceipt';
 import { useUsernameProfile } from 'apps/web/src/components/Basenames/UsernameProfileContext';
+import useWriteContractsWithLogs from 'apps/web/src/hooks/useWriteContractsWithLogs';
+import useCapabilitiesSafe from 'apps/web/src/hooks/useCapabilitiesSafe';
+import L2ReverseRegistrarAbi from 'apps/web/src/abis/L2ReverseRegistrarAbi';
 
 /*
   A hook to set a name as primary for resolution.
@@ -31,6 +34,9 @@ export default function useSetPrimaryBasename({ secondaryUsername }: UseSetPrima
 
   const { currentWalletIsProfileEditor } = useUsernameProfile();
   const { basenameChain: secondaryUsernameChain } = useBasenameChain(secondaryUsername);
+  const { paymasterService: paymasterServiceEnabled } = useCapabilitiesSafe({
+    chainId: secondaryUsernameChain.id,
+  });
 
   // Get current primary username
   // Note: This is sometimes undefined
@@ -52,6 +58,11 @@ export default function useSetPrimaryBasename({ secondaryUsername }: UseSetPrima
       eventName: 'update_primary_name',
     });
 
+  const { initiateBatchCalls, batchCallsStatus, batchCallsIsLoading } = useWriteContractsWithLogs({
+    chain: secondaryUsernameChain,
+    eventName: 'update_primary_name',
+  });
+
   useEffect(() => {
     if (transactionIsSuccess) {
       refetchPrimaryUsername()
@@ -68,17 +79,43 @@ export default function useSetPrimaryBasename({ secondaryUsername }: UseSetPrima
     if (!address) return undefined;
 
     try {
-      await initiateTransaction({
-        abi: ReverseRegistrarAbi,
-        address: USERNAME_REVERSE_REGISTRAR_ADDRESSES[secondaryUsernameChain.id],
-        args: [
-          address,
-          address,
-          USERNAME_L2_RESOLVER_ADDRESSES[secondaryUsernameChain.id],
-          secondaryUsername,
-        ],
-        functionName: 'setNameForAddr',
-      });
+      if (!paymasterServiceEnabled) {
+        await initiateTransaction({
+          abi: ReverseRegistrarAbi,
+          address: USERNAME_REVERSE_REGISTRAR_ADDRESSES[secondaryUsernameChain.id],
+          args: [
+            address,
+            address,
+            USERNAME_L2_RESOLVER_ADDRESSES[secondaryUsernameChain.id],
+            secondaryUsername,
+          ],
+          functionName: 'setNameForAddr',
+        });
+      } else {
+        await initiateBatchCalls({
+          contracts: [
+            {
+              abi: ReverseRegistrarAbi,
+              address: USERNAME_REVERSE_REGISTRAR_ADDRESSES[secondaryUsernameChain.id],
+              args: [
+                address,
+                address,
+                USERNAME_L2_RESOLVER_ADDRESSES[secondaryUsernameChain.id],
+                secondaryUsername,
+              ],
+              functionName: 'setNameForAddr',
+            },
+            {
+              abi: L2ReverseRegistrarAbi,
+              address: USERNAME_L2_RESOLVER_ADDRESSES[secondaryUsernameChain.id],
+              functionName: 'setName',
+              args: [secondaryUsername],
+            },
+          ],
+          account: address,
+          chain: secondaryUsernameChain,
+        });
+      }
     } catch (error) {
       logError(error, 'Set primary name transaction canceled');
       return undefined;
@@ -89,12 +126,24 @@ export default function useSetPrimaryBasename({ secondaryUsername }: UseSetPrima
     secondaryUsername,
     primaryUsername,
     address,
+    paymasterServiceEnabled,
     initiateTransaction,
-    secondaryUsernameChain.id,
+    secondaryUsernameChain,
+    initiateBatchCalls,
     logError,
   ]);
 
-  const isLoading = transactionIsLoading || primaryUsernameIsLoading || primaryUsernameIsFetching;
+  const isLoading =
+    transactionIsLoading ||
+    primaryUsernameIsLoading ||
+    primaryUsernameIsFetching ||
+    batchCallsIsLoading;
 
-  return { setPrimaryName, canSetUsernameAsPrimary, isLoading, transactionIsSuccess };
+  return {
+    setPrimaryName,
+    canSetUsernameAsPrimary,
+    isLoading,
+    transactionIsSuccess,
+    batchCallsStatus,
+  };
 }

--- a/apps/web/src/hooks/useSetPrimaryBasename.ts
+++ b/apps/web/src/hooks/useSetPrimaryBasename.ts
@@ -130,7 +130,7 @@ export default function useSetPrimaryBasename({ secondaryUsername }: UseSetPrima
     address,
     paymasterServiceEnabled,
     initiateTransaction,
-    secondaryUsernameChain,
+    secondaryUsernameChain.id,
     initiateBatchCalls,
     logError,
   ]);

--- a/apps/web/src/hooks/useSetPrimaryBasename.ts
+++ b/apps/web/src/hooks/useSetPrimaryBasename.ts
@@ -1,6 +1,7 @@
 import ReverseRegistrarAbi from 'apps/web/src/abis/ReverseRegistrarAbi';
 import {
   USERNAME_L2_RESOLVER_ADDRESSES,
+  USERNAME_L2_REVERSE_REGISTRAR_ADDRESSES,
   USERNAME_REVERSE_REGISTRAR_ADDRESSES,
 } from 'apps/web/src/addresses/usernames';
 import useBasenameChain from 'apps/web/src/hooks/useBasenameChain';
@@ -107,7 +108,7 @@ export default function useSetPrimaryBasename({ secondaryUsername }: UseSetPrima
             },
             {
               abi: L2ReverseRegistrarAbi,
-              address: USERNAME_L2_RESOLVER_ADDRESSES[secondaryUsernameChain.id],
+              address: USERNAME_L2_REVERSE_REGISTRAR_ADDRESSES[secondaryUsernameChain.id],
               functionName: 'setName',
               args: [secondaryUsername],
             },

--- a/apps/web/src/hooks/useSetPrimaryBasename.ts
+++ b/apps/web/src/hooks/useSetPrimaryBasename.ts
@@ -59,10 +59,11 @@ export default function useSetPrimaryBasename({ secondaryUsername }: UseSetPrima
       eventName: 'update_primary_name',
     });
 
-  const { initiateBatchCalls, batchCallsStatus, batchCallsIsLoading } = useWriteContractsWithLogs({
-    chain: secondaryUsernameChain,
-    eventName: 'update_primary_name',
-  });
+  const { initiateBatchCalls, batchCallsIsSuccess, batchCallsIsLoading } =
+    useWriteContractsWithLogs({
+      chain: secondaryUsernameChain,
+      eventName: 'update_primary_name',
+    });
 
   useEffect(() => {
     if (transactionIsSuccess) {
@@ -144,7 +145,6 @@ export default function useSetPrimaryBasename({ secondaryUsername }: UseSetPrima
     setPrimaryName,
     canSetUsernameAsPrimary,
     isLoading,
-    transactionIsSuccess,
-    batchCallsStatus,
+    transactionIsSuccess: transactionIsSuccess || batchCallsIsSuccess,
   };
 }


### PR DESCRIPTION
**What changed? Why?**

- Updated the flow for setting a primary Basename to be compatible with ensip19 
  - This PR only updates the transaction made for smart accounts. A separate PR will be made for EOAs.
  - The transaction bundles two calls - one for calling the existing `setNameForAddr` on the ReverseRegistrar, and one for calling `setName` on the L2ReverseRegistrar

**Notes to reviewers**

**How has it been tested?**


https://github.com/user-attachments/assets/04a42f2f-c124-4306-85eb-e345eee042cc



Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources
