### PR TITLE
chore: update base sepolia reverse-registrar address

### DIFF
--- a/apps/web/src/addresses/usernames.ts
+++ b/apps/web/src/addresses/usernames.ts
@@ -59,7 +59,7 @@ export const USERNAME_1155_DISCOUNT_VALIDATORS: AddressMap = {
 };
 
 export const USERNAME_REVERSE_REGISTRAR_ADDRESSES: AddressMap = {
-  [baseSepolia.id]: '0xa0A8401ECF248a9375a0a71C4dedc263dA18dCd7',
+  [baseSepolia.id]: '0x876eF94ce0773052a2f81921E70FF25a5e76841f',
   [base.id]: '0x79ea96012eea67a83431f1701b3dff7e37f9e282',
 };
 


### PR DESCRIPTION
**What changed? Why?**

As part of preparing for ENSIP-19 we had to redeploy the legacy reverse registrar. This PR adds that new contract's address to our base sepolia config.  

**Notes to reviewers**

**How has it been tested?**

Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources
