### PR TITLE
Add Zerion to Base ecosystem directory

### DIFF
--- a/apps/web/data/ecosystem/zerion/metadata.json
+++ b/apps/web/data/ecosystem/zerion/metadata.json
@@ -1,0 +1,8 @@
+{
+  "name": "Zerion",
+  "description": "Zerion is the best self-custodial wallet for everything you own onchain, helping you track and manage tokens, NFTs and DeFi positions across 55+ EVM and non EVM chains - including base.",
+  "url": "https://zerion.io/base-wallet?utm_source=baseeco",
+  "imageUrl": "https://zerion.notion.site/Zerion-Icon-342f8e9d7166489eae3aa1b602258c80",
+  "category": "wallet",
+  "subcategory": "self custody"
+}


### PR DESCRIPTION
## Summary
Add Zerion wallet to the Base ecosystem directory.

## Details
- **Name**: Zerion
- **Category**: wallet / self custody
- **Description**: Self-custodial wallet for tracking and managing tokens, NFTs and DeFi positions across 55+ chains including Base
- **URL**: https://zerion.io/base-wallet?utm_source=baseeco

## Changes
- Created `apps/web/data/ecosystem/zerion/metadata.json` with Zerion's ecosystem entry

This follows the established pattern for ecosystem entries as seen in other apps in the directory.