### PR TITLE
feat(BA-2555): Set primary flow for EOAs in Web

### DIFF
--- a/apps/web/src/components/Basenames/ManageNames/NameDisplay.tsx
+++ b/apps/web/src/components/Basenames/ManageNames/NameDisplay.tsx
@@ -45,8 +45,6 @@ type NameDisplayProps = {
   tokenId: string;
   expiresAt: string;
   refetchNames: () => void;
-  isUpdatingPrimary: boolean;
-  setIsUpdatingPrimary: (v: boolean) => void;
 };
 
 export default function NameDisplay({
@@ -55,8 +53,6 @@ export default function NameDisplay({
   tokenId,
   expiresAt,
   refetchNames,
-  isUpdatingPrimary,
-  setIsUpdatingPrimary,
 }: NameDisplayProps) {
   const router = useRouter();
   const { logEventWithContext } = useAnalytics();
@@ -64,9 +60,7 @@ export default function NameDisplay({
   const name = domain.split('.')[0];
 
   const { removeNameFromUI } = useRemoveNameFromUI();
-  const { setPrimaryUsername, isPending } = useUpdatePrimaryName(domain as Basename, {
-    setIsUpdatingPrimary,
-  });
+  const { setPrimaryUsername, isPending } = useUpdatePrimaryName(domain as Basename);
 
   // Transfer state and callbacks
   const [isTransferModalOpen, setIsTransferModalOpen] = useState<boolean>(false);
@@ -109,7 +103,7 @@ export default function NameDisplay({
         <div className="flex items-center gap-2">
           {isPrimary && (
             <span className="flex items-center gap-2 rounded-full bg-white px-2 py-1 text-sm text-black">
-              {isPending || isUpdatingPrimary ? (
+              {isPending ? (
                 <Icon name="spinner" color="currentColor" width="12px" height="12px" />
               ) : null}
               <span>Primary</span>

--- a/apps/web/src/components/Basenames/ManageNames/NamesList.tsx
+++ b/apps/web/src/components/Basenames/ManageNames/NamesList.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
 import NameDisplay from './NameDisplay';
 import { useNameList } from 'apps/web/src/components/Basenames/ManageNames/hooks';
 import { useErrors } from 'apps/web/contexts/Errors';
@@ -43,7 +43,6 @@ export default function NamesList() {
     currentPageNumber,
   } = useNameList();
   const { logError } = useErrors();
-  const [isUpdatingPrimary, setIsUpdatingPrimary] = useState(false);
 
   const refetchNames = useCallback(() => {
     refetch().catch((e) => {
@@ -95,8 +94,6 @@ export default function NamesList() {
             tokenId={name.token_id}
             expiresAt={name.expires_at}
             refetchNames={refetchNames}
-            isUpdatingPrimary={isUpdatingPrimary}
-            setIsUpdatingPrimary={setIsUpdatingPrimary}
           />
         ))}
       </ul>

--- a/apps/web/src/hooks/useSetPrimaryBasename.ts
+++ b/apps/web/src/hooks/useSetPrimaryBasename.ts
@@ -189,7 +189,7 @@ export default function useSetPrimaryBasename({ secondaryUsername }: UseSetPrima
     canSetUsernameAsPrimary,
     isLoading,
     transactionIsSuccess: transactionIsSuccess || batchCallsIsSuccess,
-    isWriting: transactionIsLoading || batchCallsIsLoading,
+    transactionPending: transactionIsLoading || batchCallsIsLoading,
     error: signatureError,
   };
 }


### PR DESCRIPTION
**What changed? Why?**
Adds the "Set primary" name flow for EOAs against new contracts (signature-based).

**Notes to reviewers**

**How has it been tested?**


https://github.com/user-attachments/assets/94478864-e4de-409b-b60d-bf1bc3071ef0






Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources
