### PR TITLE
fix: Homepage mobile blog carousel UI issue

### DIFF
--- a/apps/web/src/components/base-org/root/Redesign/Section/Blog/index.tsx
+++ b/apps/web/src/components/base-org/root/Redesign/Section/Blog/index.tsx
@@ -53,13 +53,7 @@ function BlogCarouselControls({
     [onDotClick],
   );
   return (
-    <motion.div
-      // className="absolute bottom-4 left-4 z-30 md:bottom-[52px] md:left-auto md:right-6 xl:bottom-[48px] xl:right-12"
-      className=""
-      variants={controlsVariants}
-      initial="hidden"
-      animate="visible"
-    >
+    <motion.div className="" variants={controlsVariants} initial="hidden" animate="visible">
       <div className="flex gap-3">
         {displayedPosts.map((post, index) => (
           <motion.button


### PR DESCRIPTION
**What changed? Why?**

Before:

<img width="320" alt="image" src="https://github.com/user-attachments/assets/519f65cf-0da5-45fe-89b9-78dfad7c34f0" />

After:

<img width="320" alt="image" src="https://github.com/user-attachments/assets/694e7bc8-aa54-4f50-8bb8-992a6caf5cfc" />


**Notes to reviewers**

It'd be cleaner to use context for this, and I don't love that I'm using <button> in the <Link> component, but refactoring this to be more correct would be a bigger lift.

**How has it been tested?**

Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources
