### PR TITLE
feat(BA-2817): Ensip-11 address setting during ownership transfer modal

### DIFF
--- a/apps/web/src/components/Basenames/UsernameProfileTransferOwnershipModal/context.tsx
+++ b/apps/web/src/components/Basenames/UsernameProfileTransferOwnershipModal/context.tsx
@@ -92,8 +92,6 @@ export default function ProfileTransferOwnershipProvider({
     username: profileUsername,
   });
 
-  console.log('resolverAddress', resolverAddress);
-
   // States
   const [recipientAddress, setRecipientAddress] = useState<string>('');
   const [currentOwnershipStep, setCurrentOwnershipStep] = useState<OwnershipSteps>(
@@ -111,15 +109,11 @@ export default function ProfileTransferOwnershipProvider({
 
     const nodeHash = namehash(profileUsername);
 
-    console.log('nodeHash', nodeHash);
-
     const legacyAddrData = encodeFunctionData({
       abi: L2ResolverAbi,
       functionName: 'setAddr',
       args: [nodeHash, recipientAddress],
     });
-
-    console.log('legacyAddrData', legacyAddrData);
 
     // Set addr with ENSIP-11 address
     const baseAddrData = encodeFunctionData({
@@ -127,8 +121,6 @@ export default function ProfileTransferOwnershipProvider({
       functionName: 'setAddr',
       args: [nodeHash, BigInt(convertChainIdToCoinTypeUint(basenameChain.id)), recipientAddress],
     });
-
-    console.log('baseAddrData', baseAddrData);
 
     return {
       abi: L2ResolverAbi,

--- a/apps/web/src/components/Basenames/UsernameProfileTransferOwnershipModal/context.tsx
+++ b/apps/web/src/components/Basenames/UsernameProfileTransferOwnershipModal/context.tsx
@@ -128,7 +128,13 @@ export default function ProfileTransferOwnershipProvider({
       args: [nodeHash, [legacyAddrData, baseAddrData]],
       functionName: 'multicallWithNodeCheck',
     } as ContractFunctionParameters;
-  }, [isValidRecipientAddress, profileUsername, recipientAddress, resolverAddress]);
+  }, [
+    isValidRecipientAddress,
+    profileUsername,
+    recipientAddress,
+    resolverAddress,
+    basenameChain.id,
+  ]);
 
   // Step 2, reclaim the basename
   const reclaimContract = useMemo(() => {

--- a/apps/web/src/components/Basenames/UsernameProfileTransferOwnershipModal/context.tsx
+++ b/apps/web/src/components/Basenames/UsernameProfileTransferOwnershipModal/context.tsx
@@ -31,7 +31,7 @@ import useWriteContractsWithLogs, {
 } from 'apps/web/src/hooks/useWriteContractsWithLogs';
 import useBasenameResolver from 'apps/web/src/hooks/useBasenameResolver';
 import L2ReverseRegistrarAbi from 'apps/web/src/abis/L2ReverseRegistrarAbi';
-import { convertChainIdToCoinTypeUint, formatBaseEthDomain } from 'apps/web/src/utils/usernames';
+import { convertChainIdToCoinTypeUint } from 'apps/web/src/utils/usernames';
 
 type ProfileTransferOwnershipProviderProps = {
   children?: ReactNode;

--- a/apps/web/src/components/Modal/index.tsx
+++ b/apps/web/src/components/Modal/index.tsx
@@ -45,7 +45,7 @@ export default function Modal({
   );
 
   const dialogClasses = classNames(
-    'md:border-gray-40/20 flex h-screen max-h-screen overflow-y-scroll md:h-full w-full flex-col gap-4 md:rounded-3xl md:border bg-white p-6 md:p-10 shadow-lg sm:h-auto ',
+    'md:border-gray-40/20 flex h-screen max-h-screen overflow-y-auto md:h-full w-full flex-col gap-4 md:rounded-3xl md:border bg-white p-6 md:p-10 shadow-lg sm:h-auto ',
     {
       'max-w-lg': size === ModalSizes.Medium,
       'max-w-xl': size === ModalSizes.Large,

--- a/apps/web/src/components/WalletIdentity/index.tsx
+++ b/apps/web/src/components/WalletIdentity/index.tsx
@@ -6,7 +6,7 @@ import useBaseEnsName from 'apps/web/src/hooks/useBaseEnsName';
 import useBasenameChain from 'apps/web/src/hooks/useBasenameChain';
 import { getBasenameImage } from 'apps/web/src/utils/usernames';
 import { truncateMiddle } from 'libs/base-ui/utils/string';
-import Image from 'next/image';
+import ImageWithLoading from 'apps/web/src/components/ImageWithLoading';
 import { Address } from 'viem';
 import { mainnet } from 'viem/chains';
 import { useEnsAvatar, useEnsName } from 'wagmi';
@@ -49,7 +49,17 @@ export default function WalletIdentity({ address }: { address: Address }) {
         <Avatar
           address={address}
           chain={basenameChain}
-          defaultComponent={<Image src={avatar} height={32} width={32} alt={deterministicName} />}
+          defaultComponent={
+            <ImageWithLoading
+              src={avatar}
+              alt={deterministicName}
+              width={32}
+              height={32}
+              wrapperClassName="h-8 w-8 overflow-hidden rounded-full"
+              imageClassName="object-cover w-full h-full"
+              backgroundClassName="bg-blue-500"
+            />
+          }
         />
       )}
 

--- a/apps/web/src/hooks/useBasenameResolver.ts
+++ b/apps/web/src/hooks/useBasenameResolver.ts
@@ -42,7 +42,7 @@ export default function useBasenameResolver({
   });
 
   return {
-    data: resolverAddress as Address | undefined,
+    data: resolverAddress,
     isError,
     error,
     refetch,

--- a/apps/web/src/hooks/useBasenameResolver.ts
+++ b/apps/web/src/hooks/useBasenameResolver.ts
@@ -1,0 +1,50 @@
+import { useReadContract } from 'wagmi';
+import { namehash, type Address } from 'viem';
+import { type Basename } from '@coinbase/onchainkit/identity';
+import { getChainForBasename } from 'apps/web/src/utils/usernames';
+import { USERNAME_BASE_REGISTRY_ADDRESSES } from 'apps/web/src/addresses/usernames';
+import RegistryAbi from 'apps/web/src/abis/RegistryAbi';
+
+export type UseBasenameResolverProps = {
+  username: Basename;
+};
+
+export type UseBasenameResolverReturn = {
+  data: Address | undefined;
+  isError: boolean;
+  error: Error | null;
+  refetch: () => Promise<unknown>;
+};
+
+/**
+ * Hook to fetch the resolver contract address for a given basename from the registry contract
+ */
+export default function useBasenameResolver({
+  username,
+}: UseBasenameResolverProps): UseBasenameResolverReturn {
+  const chain = getChainForBasename(username);
+  const nodeHash = namehash(username as string);
+
+  const {
+    data: resolverAddress,
+    isError,
+    error,
+    refetch,
+  } = useReadContract({
+    abi: RegistryAbi,
+    address: USERNAME_BASE_REGISTRY_ADDRESSES[chain.id],
+    functionName: 'resolver',
+    args: [nodeHash],
+    query: {
+      enabled: !!username,
+      refetchOnWindowFocus: false,
+    },
+  });
+
+  return {
+    data: resolverAddress as Address | undefined,
+    isError,
+    error,
+    refetch,
+  };
+}


### PR DESCRIPTION
**What changed? Why?**

This [tx](https://basescan.org/tx/0x39f4af11b007b7ea5e9a834900e6e8e1389fb5d877880f37a3380ff881683ee7) was submitted via the ownership transfer flow. Can see in the calldata that this is a multicall resolver set. Querying the resolver directly shows that the data was updated according to expectations: 
<img width="489" height="700" alt="Screenshot 2025-09-17 at 11 04 09 AM" src="https://github.com/user-attachments/assets/3042fd39-b25a-46db-a8c4-8e58d7ba6fd7" />

[Tenderly sim](https://www.tdly.co/tx/0x39f4af11b007b7ea5e9a834900e6e8e1389fb5d877880f37a3380ff881683ee7)

**Notes to reviewers**

**How has it been tested?**

Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources
