### PR TITLE
chore(BA-2884): Fix regression in clearing primary name

### DIFF
--- a/apps/web/src/components/Basenames/UsernameProfileTransferOwnershipModal/context.tsx
+++ b/apps/web/src/components/Basenames/UsernameProfileTransferOwnershipModal/context.tsx
@@ -24,13 +24,13 @@ import L2ResolverAbi from 'apps/web/src/abis/L2Resolver';
 import BaseRegistrarAbi from 'apps/web/src/abis/BaseRegistrarAbi';
 import {
   USERNAME_BASE_REGISTRAR_ADDRESSES,
-  USERNAME_L2_REVERSE_REGISTRAR_ADDRESSES,
+  USERNAME_REVERSE_REGISTRAR_ADDRESSES,
 } from 'apps/web/src/addresses/usernames';
 import useWriteContractsWithLogs, {
   BatchCallsStatus,
 } from 'apps/web/src/hooks/useWriteContractsWithLogs';
 import useBasenameResolver from 'apps/web/src/hooks/useBasenameResolver';
-import L2ReverseRegistrarAbi from 'apps/web/src/abis/L2ReverseRegistrarAbi';
+import ReverseRegistrarAbi from 'apps/web/src/abis/ReverseRegistrarAbi';
 import { convertChainIdToCoinTypeUint } from 'apps/web/src/utils/usernames';
 
 type ProfileTransferOwnershipProviderProps = {
@@ -157,8 +157,8 @@ export default function ProfileTransferOwnershipProvider({
   // Step 4, set the reverse resolution record
   const setNameContract = useMemo(() => {
     return {
-      abi: L2ReverseRegistrarAbi,
-      address: USERNAME_L2_REVERSE_REGISTRAR_ADDRESSES[basenameChain.id],
+      abi: ReverseRegistrarAbi,
+      address: USERNAME_REVERSE_REGISTRAR_ADDRESSES[basenameChain.id],
       args: [''],
       functionName: 'setName',
     } as ContractFunctionParameters;


### PR DESCRIPTION
**What changed? Why?**

When a user actions through the change ownership modal, the last step is to clear their primary name record. With legacy reverse resolution, this is needed since the data is read directly from state and is not close-loop checked against forward resolution data.

In #2622 I incorrectly added a regression that cleared the data in the ENS L2ReverseRegistrar. This _isn't_ necessary since all ENSIP-19 requests are proprely close-loop checked and the data that would be involved in said check is edited in step one of this flow. 

This PR fixes that regression by going back to clearing only the legacy data. We will be able to remove this entirely once we deprecate legacy reverse writes. 

**Notes to reviewers**

**How has it been tested?**

Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources
