### PR TITLE
fix: Base Build sidebar link

### DIFF
--- a/apps/web/src/components/Layout/Navigation/Sidebar/Base-Sidebar.tsx
+++ b/apps/web/src/components/Layout/Navigation/Sidebar/Base-Sidebar.tsx
@@ -360,7 +360,7 @@ export function BaseNavigation({ isMobile = false }: { isMobile?: boolean }) {
               className="w-full"
             >
               <Link
-                href="https://docs.base.org/wallet-app/introduction/getting-started"
+                href="https://docs.base.org/mini-apps/quickstart/new-apps/install"
                 target="_blank"
                 rel="noreferrer noopener"
               >


### PR DESCRIPTION
**What changed? Why?**

- Updates sidebar link in Base Build sidebar

**Notes to reviewers**

**How has it been tested?**

Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources
