### PR TITLE
Updated package.json Repo URL format

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@base-org/base-web",
   "version": "1.0.0",
-  "description": "Base web monorepo",
-  "repository": "git@github.com::base/base-web.git",
+  "description": "Base Web monorepo",
+  "repository": "git@github.com:base/base-web.git",
   "license": "Apache-2.0",
   "scripts": {
     "build": "yarn workspaces foreach --exclude @app/bridge run build",


### PR DESCRIPTION
**What changed? Why?**

- Corrected repository URL by removing the extra colon to follow standard SSH format
- Capitalized "Web" in the package description for consistency with project naming

**Notes to reviewers**

**How has it been tested?**

Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources
