### PR TITLE
fix: unsafe string replacement when handling public paths

### DIFF
--- a/apps/web/scripts/pullLatestBlogPosts.js
+++ b/apps/web/scripts/pullLatestBlogPosts.js
@@ -163,7 +163,7 @@ async function main() {
 
     const publicImagePath = path.join('public', 'images', 'blog', fileName);
     await downloadImage(post.imageUrl, publicImagePath);
-    post.publicImagePath = publicImagePath.replace('public', '');
+    post.publicImagePath = '/' + path.relative('public', publicImagePath);
   }
 
   // Save the results as JSON


### PR DESCRIPTION
**What changed? Why?**
replaced the unsafe `.replace('public', '')` with `path.relative` to ensure only the leading "public" folder is removed from paths. this prevents accidental removal of "public" appearing elsewhere in the string.

**Notes to reviewers**
logic now correctly handles all public image paths without affecting other parts of the path.

**How has it been tested?**
verified that `post.publicImagePath` resolves correctly for various paths, including edge cases where "public" appears mid-path.

BaseWeb

* [x] base.org
* [x] base.org/names
* [x] base.org/builders
* [x] base.org/ecosystem
* [x] base.org/name/jesse
* [x] base.org/manage-names
* [x] base.org/resources
