### PR TITLE
Update Base Build page CTAs and footer social links

### DIFF
--- a/apps/web/src/components/Layout/Footer/Footer.tsx
+++ b/apps/web/src/components/Layout/Footer/Footer.tsx
@@ -75,7 +75,7 @@ const LINK_SECTIONS = [
     title: 'Socials',
     links: [
       { label: 'X', href: 'https://x.com/base', newTab: true },
-      { label: 'Farcaster', href: 'https://farcaster.xyz/base', newTab: true },
+      { label: 'Base App', href: 'https://base.app', newTab: true },
       { label: 'Discord', href: 'https://discord.com/invite/buildonbase', newTab: true },
       { label: 'Reddit', href: 'https://www.reddit.com/r/BASE/', newTab: true },
     ],

--- a/apps/web/src/components/Layout/Navigation/Sidebar/Base-Sidebar.tsx
+++ b/apps/web/src/components/Layout/Navigation/Sidebar/Base-Sidebar.tsx
@@ -349,8 +349,12 @@ export function BaseNavigation({ isMobile = false }: { isMobile?: boolean }) {
               asChild
               className="w-full"
             >
-              <Link href="https://www.base.dev/" target="_blank" rel="noreferrer noopener">
-                Grow your app
+              <Link
+                href="https://docs.base.org/get-started/base"
+                target="_blank"
+                rel="noreferrer noopener"
+              >
+                See the docs
               </Link>
             </Button>
             <Button
@@ -359,11 +363,7 @@ export function BaseNavigation({ isMobile = false }: { isMobile?: boolean }) {
               asChild
               className="w-full"
             >
-              <Link
-                href="https://docs.base.org/mini-apps/quickstart/new-apps/install"
-                target="_blank"
-                rel="noreferrer noopener"
-              >
+              <Link href="https://www.base.dev/" target="_blank" rel="noreferrer noopener">
                 Start building
               </Link>
             </Button>


### PR DESCRIPTION
**What changed? Why?**

- Change base.org/build secondary button text from 'Grow your app' to 'See the docs'
- Update base.org/build secondary button link to docs.base.org/get-started/base
- Update base.org/build primary button link from docs to base.dev
- Update footer social links

**Notes to reviewers**

**How has it been tested?**

locally

Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources
