### PR TITLE
Update CONTRIBUTING.md grammar and clarity

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 👍🎉 First off, thank you for considering contributing to Base Web! 🎉👍
 
-The following is a set of guidelines for contributing to Base Web. These are just guidelines, not rules. Use your best judgment, and feel free to propose changes to this document in a pull request.
+These are guidelines for contributing to Base Web, not strict rules. Use your best judgment, and feel free to propose changes to this document in a pull request.
 
 ## Table of Contents
 
@@ -15,7 +15,7 @@ The following is a set of guidelines for contributing to Base Web. These are jus
 
 ## Code of Conduct
 
-This project and everyone participating in it is governed by our [Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code.
+This project and all participants are governed by our [Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code.
 
 ## How Can I Contribute?
 
@@ -23,11 +23,11 @@ This project and everyone participating in it is governed by our [Code of Conduc
 
 1. **Ensure the bug was not already reported** by searching on GitHub under [Issues](https://github.com/base/web/issues).
 
-2. If you're unable to find an open issue addressing the problem, [open a new one](https://github.com/base/web/issues/new). Be sure to include a **title and clear description**, as much relevant information as possible, and a **code sample** or an **executable test case** demonstrating the expected behavior that is not occurring.
+2. If you're unable to find an open issue addressing the problem, [open a new one](https://github.com/base/web/issues/new). Include a ** clear title, detailed description**, relevant information, and a **code sample** or **executable test case** demonstrating the expected behavior that is not occurring.
 
 ### Suggesting Enhancements
 
-1. **Check the [Issues](https://github.com/base/web/issues)** to see if there's someone who has already suggested the same enhancement.
+1. **Check [Issues](https://github.com/base/web/issues)** to see if the enhancement has already been suggested.
 
 2. If it doesn't exist, [create a new issue](https://github.com/base/web/issues/new). Provide a clear and detailed explanation of the feature you want and why it's important to add.
 
@@ -37,13 +37,13 @@ This project and everyone participating in it is governed by our [Code of Conduc
 
 2. **Make your changes**: Apply your changes, following the coding conventions described below.
 
-3. **Commit your changes**: Commit your changes using a descriptive commit message.
+3. **Commit your changes**: Use a clear, descriptive commit message.
 
-4. **Open a Pull Request**: Describe what you did in the pull request description. Mention the issue number if your pull request is related to an existing issue. 
+4. **Open a Pull Request**: In your pull request, describe your changes and reference any related issues.
 
 5. **Include Screenshots**: If your pull request includes any visual changes to the project, please include before and after screenshots in your pull request description to help us better understand the changes.
 
-6. **Wait for review**: Once your pull request is opened, it will be reviewed as soon as possible. Changes may be requested, and your responsiveness is appreciated.
+6. **Wait for review**:After opening a pull request, it will be reviewed promptly. Changes may be requested, so please respond quickly.
 
 ## Coding Conventions
 


### PR DESCRIPTION
**What changed? Why?**

Refined CONTRIBUTING.md for readability and consistency:

- Simplified opening sentence to avoid repetition.
- Fixed subject-verb agreement in Code of Conduct section.
- Rewrote bug reporting instructions for conciseness and clarity.
- And much more


**Notes to reviewers**

**How has it been tested?**

Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources
