### PR TITLE
Update COOP header for /pay route

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -284,6 +284,17 @@ module.exports = MillionLint.next({
             basePath: false,
             headers: securityHeaders,
           },
+          {
+            source: '/pay',
+            basePath: false,
+            headers: [
+              ...securityHeaders,
+              {
+                key: 'Cross-Origin-Opener-Policy',
+                value: 'unsafe-none',
+              },
+            ],
+          },
         ];
       },
       async rewrites() {


### PR DESCRIPTION
**What changed? Why?**

- The `Cross-Origin-Opener-Policy` for the /pay route specifically needs to be set to `unsafe-none` because this route needs to be opened by keys.coinbase.com. It's currently set to `same-origin-allow-popups` which causes a browser error when we try to open it

**Notes to reviewers**

**How has it been tested?**

- Manually.

On /pay:
<img width="660" height="65" alt="Screenshot 2025-09-30 at 3 36 17 PM" src="https://github.com/user-attachments/assets/432bc575-d1f0-4584-8087-ba52d53ed5d2" />


On all other routes:

<img width="647" height="50" alt="Screenshot 2025-09-30 at 3 36 03 PM" src="https://github.com/user-attachments/assets/3aa86a07-8768-4bac-812f-dfd6b401ca1f" />



Have you tested the following pages?

BaseWeb
- [x] base.org
- [x] base.org/names
- [x] base.org/builders
- [x] base.org/ecosystem
- [x] base.org/name/jesse
- [x] base.org/manage-names
- [x] base.org/resources
