### PR TITLE
Fix "onchain score" component by updating to Etherscan API V2

### DIFF
--- a/apps/web/app/(basenames)/api/proxy/route.ts
+++ b/apps/web/app/(basenames)/api/proxy/route.ts
@@ -43,32 +43,12 @@ export async function GET(req: NextRequest) {
     });
 
     const contentType = externalResponse.headers.get('content-type');
-    const maskedApiUrl = apiUrl.replace(/(apikey=)[^&]+/i, '$1****');
     let responseData;
     if (contentType?.includes('application/json')) {
       responseData = await externalResponse.json();
     } else {
       responseData = await externalResponse.text();
     }
-
-    // Log upstream V1 deprecation warnings safely (masked URL)
-    try {
-      const maybeJson = typeof responseData === 'string' ? JSON.parse(responseData) : responseData;
-      if (
-        maybeJson?.status === '0' &&
-        typeof maybeJson?.message === 'string' &&
-        maybeJson.message.toLowerCase().includes('deprecated')
-      ) {
-        console.warn('[api/proxy] Upstream API deprecation warning', {
-          apiType,
-          apiUrl: maskedApiUrl,
-          message: maybeJson.message,
-        });
-      }
-    } catch {
-      // ignore non-JSON bodies
-    }
-
     if (externalResponse.ok) {
       return NextResponse.json({ data: responseData });
     } else {

--- a/apps/web/app/(basenames)/api/proxy/route.ts
+++ b/apps/web/app/(basenames)/api/proxy/route.ts
@@ -2,7 +2,6 @@ import { NextRequest, NextResponse } from 'next/server';
 import { isAddress } from 'viem';
 
 const ETHERSCAN_API_KEY = process.env.ETHERSCAN_API_KEY;
-const BASESCAN_API_KEY = process.env.BASESCAN_API_KEY;
 const TALENT_PROTOCOL_API_KEY = process.env.TALENT_PROTOCOL_API_KEY;
 
 export async function GET(req: NextRequest) {

--- a/apps/web/src/components/Basenames/UsernameProfileSectionHeatmap/index.tsx
+++ b/apps/web/src/components/Basenames/UsernameProfileSectionHeatmap/index.tsx
@@ -6,7 +6,7 @@ import {
 } from 'apps/web/src/components/Basenames/UsernameProfileSectionHeatmap/contracts';
 import { Icon } from 'apps/web/src/components/Icon/Icon';
 import Image from 'next/image';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { ComponentType, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import CalendarHeatmap, { ReactCalendarHeatmapValue } from 'react-calendar-heatmap';
 import { Address } from 'viem';
 import './cal.css';
@@ -162,12 +162,19 @@ export default function UsernameProfileSectionHeatmap() {
     };
   };
 
+  type EtherscanEnvelope = {
+    status?: '1' | '0';
+    message?: string;
+    result?: unknown;
+    data?: { result?: unknown };
+  };
+
   const fetchTransactions = useCallback(
     async (apiUrl: string, retryCount = 3): Promise<Transaction[]> => {
       try {
         const response = await fetch(apiUrl);
-        const json = (await response.json()) as any;
-        const data = json?.data ?? json;
+        const json = (await response.json()) as EtherscanEnvelope | { data?: EtherscanEnvelope };
+        const data: EtherscanEnvelope = (json as any)?.data ?? (json as EtherscanEnvelope);
 
         if (data?.status === '1' && Array.isArray(data?.result)) {
           return data.result as Transaction[];
@@ -455,14 +462,21 @@ export default function UsernameProfileSectionHeatmap() {
             style={{ direction: 'rtl' }}
             className="w-full max-w-full overflow-x-auto overflow-y-hidden whitespace-nowrap"
           >
-            <CalendarHeatmap
-              startDate={new Date(new Date().setFullYear(new Date().getFullYear() - 1))}
-              endDate={new Date()}
-              horizontal
-              values={heatmapData}
-              classForValue={classForValue}
-              titleForValue={titleForValue}
-            />
+            {(() => {
+              const AnyCalendarHeatmap = CalendarHeatmap as unknown as ComponentType<
+                Record<string, unknown>
+              >;
+              return (
+                <AnyCalendarHeatmap
+                  startDate={new Date(new Date().setFullYear(new Date().getFullYear() - 1))}
+                  endDate={new Date()}
+                  horizontal
+                  values={heatmapData}
+                  classForValue={classForValue}
+                  titleForValue={titleForValue}
+                />
+              );
+            })()}
           </div>
         </div>
         <Collapsible.Trigger className="flex w-full flex-row items-center border-t border-palette-line/20 px-6 py-4">


### PR DESCRIPTION
**What changed? Why?**
This PR updates the route that feeds our onchain score component at base.org/name/YOUR_BASENAME.

**Notes to reviewers**

**How has it been tested?**
Before:
<img width="1535" height="674" alt="Screenshot 2025-10-02 at 3 37 52 PM" src="https://github.com/user-attachments/assets/0711154f-4af1-40d8-aacf-4ee6c49b5f39" />

After:
<img width="1476" height="644" alt="Screenshot 2025-10-02 at 3 37 39 PM" src="https://github.com/user-attachments/assets/a699a789-b94d-44e3-acda-a2d6c0d24da9" />


Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [x] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources
