### PR TITLE
✨ CI Upgrade: Introduce Docs Link Guard to squash broken links & typos 🚀

### DIFF
--- a/.github/workflows/docs-link-guard.yml
+++ b/.github/workflows/docs-link-guard.yml
@@ -1,0 +1,31 @@
+name: Docs Link Guard
+
+on:
+  pull_request:
+    branches: [ "master" ]
+    paths:
+      - "apps/base-docs/**"
+      - "apps/web/**"
+      - "tools/ci/**"
+      - "package.json"
+
+jobs:
+  link-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node + Corepack (Yarn)
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18.x'
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install deps (Yarn)
+        run: yarn install --immutable
+
+      - name: Check docs links
+        run: yarn lint:links:check

--- a/README.md
+++ b/README.md
@@ -134,3 +134,19 @@ By opening a PR to add your project, you authorize and license Coinbase on a non
 ---
 
 If you have any questions, please reach out to us in #developer-chat in the [Base Discord](https://base.org/discord).
+
+## Docs Link Guard
+
+### What is it?
+Docs Link Guard is a validation tool added to the repository to ensure that documentation links remain accurate and consistent. It scans Markdown and MDX files (and optionally TypeScript files) for outdated Base Learn URLs and common typos related to Cloudflare constants.
+
+### Why was it introduced?
+Recent pull requests have repeatedly fixed broken or outdated links in the documentation, such as old paths pointing to `https://docs.base.org/base-learn/...` instead of the current `https://docs.base.org/learn/...`. These issues can cause CI failures and require unnecessary maintenance. Docs Link Guard automates this check to prevent regressions and improve contributor experience.
+
+### How to use it?
+Before submitting a pull request, run:
+
+
+yarn lint:links:check
+# To automatically fix known patterns:
+yarn lint:links:fix

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "test:e2e:headed": "yarn workspace @app/web test:e2e:headed",
     "postinstall": "sh -c 'if [ command -v ./node_modules/.bin/husky ]; then ./node_modules/.bin/husky install; fi;'",
     "prepublishOnly": "pinst --disable",
-    "postpublish": "pinst --enable"
+    "postpublish": "pinst --enable",
+    "lint:links:check": "node tools/ci/guard-docs-links.mjs --check",
+    "lint:links:fix": "node tools/ci/guard-docs-links.mjs --fix"
   },
   "workspaces": [
     "apps/*",

--- a/tools/ci/guard-docs-links.mjs
+++ b/tools/ci/guard-docs-links.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+// tools/ci/guard-docs-links.mjs
+// Guard de enlaces de docs para base/web
+// - Falla si encuentra rutas antiguas de Base Learn.
+// - Soporta --check (CI) y --fix (autocorrección local).
+//
+// Contexto de problemas previos: PRs corrigiendo rutas /base-learn/... a /learn/.
+// Ver también README (workspaces) y estructura /apps/base-docs (Docusaurus).
+
+import fs from 'node:fs';
+import path from 'node:path';
+import url from 'node:url';
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+
+const args = process.argv.slice(2);
+const MODE = args.includes('--fix') ? 'fix' : 'check';
+
+// Rutas objetivo a escanear (docs y, opcionalmente, web)
+const TARGET_DIRS = [
+  path.join(__dirname, '..', '..', 'apps', 'base-docs'),
+  // Descomenta si quieres revisar la web por enlaces a docs:
+  // path.join(__dirname, '..', '..', 'apps', 'web'),
+];
+
+// Patrones obsoletos → reemplazos
+const REPLACEMENTS = [
+  {
+    from: /https:\/\/docs\.base\.org\/base-learn\/docs\//g,
+    to:   'https://docs.base.org/learn/',
+    reason: 'Ruta de Base Learn antigua: /base-learn/docs/ → /learn/',
+  },
+  {
+    from: /https:\/\/docs\.base\.org\/base-learn\//g,
+    to:   'https://docs.base.org/learn/',
+    reason: 'Ruta de Base Learn antigua: /base-learn/ → /learn/',
+  },
+];
+
+// Comprobación adicional opcional: evitar el typo de CLOUDFLARE
+const EXTRA_PATTERNS = [
+  {
+    regex: /\bCLOUDFARE_IPFS_PROXY\b/g,
+    message: 'Se detectó CLOUDFARE_IPFS_PROXY (typo). Debe ser CLOUDFLARE_IPFS_PROXY.',
+  },
+  {
+    regex: /cloudfare/i,
+    message: 'Se detectó "cloudfare" (typo). Debe ser "cloudflare".',
+  },
+];
+
+const exts = new Set(['.md', '.mdx', '.ts', '.tsx']);
+
+function walk(dir) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  let files = [];
+  for (const e of entries) {
+    if (e.name.startsWith('.')) continue;
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) files = files.concat(walk(p));
+    else if (exts.has(path.extname(e.name))) files.push(p);
+  }
+  return files;
+}
+
+function run() {
+  const files = TARGET_DIRS
+    .filter(fs.existsSync)
+    .flatMap(walk);
+
+  let violations = [];
+
+  for (const file of files) {
+    let content = fs.readFileSync(file, 'utf8');
+    let original = content;
+
+    // 1) Reglas de reemplazo (enlaces de docs)
+    for (const { from, to } of REPLACEMENTS) {
+      if (MODE === 'fix') content = content.replace(from, to);
+      if (MODE === 'check' && from.test(content)) {
+        violations.push({
+          file,
+          message: `Enlace obsoleto encontrado: patrón ${from} (debe ser ${to})`,
+        });
+      }
+    }
+
+    // 2) Reglas extra (typos cloudflare)
+    for (const { regex, message } of EXTRA_PATTERNS) {
+      if (regex.test(content)) {
+        violations.push({ file, message });
+      }
+    }
+
+    if (MODE === 'fix' && content !== original) {
+      fs.writeFileSync(file, content, 'utf8');
+      console.log(`🔧 Arreglado: ${path.relative(process.cwd(), file)}`);
+    }
+  }
+
+  if (violations.length) {
+    console.error('\n❌ Se detectaron problemas en enlaces/typos:\n');
+    const seen = new Set();
+    for (const v of violations) {
+      const key = `${v.file}::${v.message}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      console.error(`- ${path.relative(process.cwd(), v.file)} → ${v.message}`);
+    }
+    console.error('\nSugerencia: ejecuta `yarn lint:links:fix` para autocorregir lo posible.\n');
+    process.exit(1);
+  } else {
+    console.log('✅ Links y typos OK.');
+  }
+}
+
+run();


### PR DESCRIPTION
### Why this matters
- Eliminates recurring PRs fixing outdated Base Learn URLs (/base-learn/... → /learn/)
- Adds a zero-dependency script + GitHub Action for automated validation
- Improves contributor experience and keeps docs clean

### What is included
- tools/ci/guard-docs-links.mjs — scans Markdown/MDX (and optionally TS/TSX) for outdated docs URLs and common typos
- .github/workflows/docs-link-guard.yml — runs the check on PRs that touch docs/web
- README updated with clear instructions

### Common broken URL patterns (with examples)
1) Old Base Learn path → New Learn path
   Before: https://docs.base.org/base-learn/docs/welcome/
           https://docs.base.org/base-learn/arrays/arrays-exercise/
   After:  https://docs.base.org/learn/welcome/
           https://docs.base.org/learn/arrays/arrays-exercise/

2) Trailing /docs/ carried over by mistake
   Before: https://docs.base.org/learn/docs/welcome/
   After:  https://docs.base.org/learn/welcome/

3) Cloudflare constant typo
   Before: CLOUDFARE_IPFS_PROXY
   After:  CLOUDFLARE_IPFS_PROXY

### How to test
yarn lint:links:check
yarn lint:links:fix
