### PR TITLE
Add ProductMint to Base Ecosystem

### DIFF
--- a/apps/web/src/data/ecosystem.json
+++ b/apps/web/src/data/ecosystem.json
@@ -3160,6 +3160,14 @@
     "subcategory": "developer tool"
   },
   {
+    "name": "ProductMint",
+    "description": "Tokenize products and subscriptions as tradable RWAs via NFTs, with automated renewals, dynamic pricing, and lower fees than legacy payment processors. No Web2 dependencies, true ownership for all.",
+    "url": "https://productmint.io",
+    "imageUrl": "/images/partners/product-mint.png",
+    "category": "consumer",
+    "subcategory": "real world"
+  },
+  {
     "name": "Prophouse",
     "url": "https://prop.house",
     "description": "Prop House is public infrastructure by Nouns DAO that helps internet communities incentivize ecosystem development.",
@@ -4606,13 +4614,5 @@
     "imageUrl": "/images/partners/levva.png",
     "category": "defi",
     "subcategory": "portfolios"
-  },
-  {
-    "name": "ProductMint",
-    "description": "Tokenize products and subscriptions as tradable RWAs via NFTs, with automated renewals, dynamic pricing, and lower fees than legacy payment processors. No Web2 dependencies, true ownership for all.",
-    "url": "https://productmint.io",
-    "imageUrl": "/images/partners/product-mint.png",
-    "category": "consumer",
-    "subcategory": "real world"
   }
 ]

--- a/apps/web/src/data/ecosystem/product-mint/metadata.json
+++ b/apps/web/src/data/ecosystem/product-mint/metadata.json
@@ -1,8 +1,0 @@
-{
-  "name": "ProductMint",
-  "description": "Tokenize products and subscriptions as tradable RWAs via NFTs, with automated renewals, dynamic pricing, and lower fees than legacy payment processors. No Web2 dependencies, true ownership for all.",
-  "url": "https://productmint.io",
-  "imageUrl": "/images/partners/product-mint.png",
-  "category": "consumer",
-  "subcategory": "real world"
-}


### PR DESCRIPTION
**What changed? Why?**

Added [ProductMint](https://productmint.io) to the Base Ecosystem page, the worlds first fully decentralized crypto subscription payment processor.

**Notes to reviewers**

Met with Spencer Stock to discuss future of on-chain subscriptions. 

Already processed over 10k in TPV on Base.

Ticket `58665792` in Base discord created and working with `rema.base.eth` to onboard ProductMint.

**How has it been tested?**

Built and ran locally to ensure all pages render properly.

Have you tested the following pages?

BaseWeb
- [x] base.org
- [x] base.org/ecosystem