### PR TITLE
Fix Tailwind CSS class typo in PolicyBanner button

### DIFF
--- a/apps/web/src/components/Banner/PolicyBanner.tsx
+++ b/apps/web/src/components/Banner/PolicyBanner.tsx
@@ -40,7 +40,7 @@ export function PolicyBanner() {
             updated policy.
           </div>
           <button
-            className="text-md text-md transition-allactive:bg-[#06318E] flex w-auto items-center justify-center gap-3 whitespace-nowrap rounded-lg border px-4 py-2 text-black disabled:pointer-events-none disabled:opacity-40 dark:text-white"
+            className="text-md text-md transition-all active:bg-[#06318E] flex w-auto items-center justify-center gap-3 whitespace-nowrap rounded-lg border px-4 py-2 text-black disabled:pointer-events-none disabled:opacity-40 dark:text-white"
             type="button"
             onClick={onDismiss}
           >


### PR DESCRIPTION
## Summary

Fixes a typo in the PolicyBanner component's button className where Tailwind CSS classes were concatenated without proper spacing.

## Changes

- Fixed `transition-allactive:bg-[#06318E]` → `transition-all active:bg-[#06318E]`
- Added missing space between `transition-all` and `active:bg-[#06318E]` classes

## Impact

This ensures:
- Tailwind CSS properly parses and applies both classes
- The active state background color (`#06318E`) is correctly applied when the button is clicked
- The transition animation works as intended

## Testing

The fix can be verified by:
1. Inspecting the button element to confirm both classes are present
2. Clicking the button to verify the active state styling applies correctly

Closes #2502