### PR TITLE
Update Guild URL to ERA platform for Base Learn badge

### DIFF
--- a/apps/web/src/components/Basenames/UsernameProfileSectionBadges/Badges/index.tsx
+++ b/apps/web/src/components/Basenames/UsernameProfileSectionBadges/Badges/index.tsx
@@ -106,7 +106,7 @@ export const BADGE_INFO: Record<
     description:
       'You completed these Base Learn Modules: Basic Contracts, Storage, Control Structures, Arrays, Inheritance, Mappings, Structs, Error Flags, New Keyword, and Imports.',
     cta: 'Go to Base Learn',
-    ctaLink: 'https://guild.xyz/base/base-learn',
+    ctaLink: 'https://era.guild.xyz/base/',
     image: baseLearnNewcomer,
     grayImage: baseLearnNewcomerGray,
   },


### PR DESCRIPTION
## Summary

Updates the Guild platform URL for the Base Learn Newcomer badge to point to the new ERA platform.

## Changes

- Updated  for  badge
- Changed from  to 

## Context

Guild.xyz has migrated to the ERA platform (era.guild.xyz). The Base Learn Newcomer badge was still pointing to the old URL, causing users to be directed to an outdated link when clicking "Go to Base Learn".

## Testing

- Verified the new URL is correct and accessible
- Confirmed the link now directs to the current Guild ERA platform

Fixes #578