### PR TITLE
chore: remove unused dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,9 +94,7 @@
     "@radix-ui/react-tooltip": "^1.1.2",
     "classnames": "^2.3.2",
     "clsx": "^1.2.1",
-    "moment": "^2.29.4",
-    "next": "15.1.6",
-    "tslib": "^2.3.0"
+    "next": "15.1.6"
   },
   "lint-staged": {
     "*.{ts,tsx}": "eslint --cache --fix",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1813,7 +1813,6 @@ __metadata:
     jest: ^29.4.1
     jest-environment-jsdom: ^29.4.1
     lint-staged: ">=10"
-    moment: ^2.29.4
     next: 15.1.6
     pinst: ">=2"
     prettier: ^2.7.1
@@ -1821,7 +1820,6 @@ __metadata:
     react-test-renderer: 18.2.0
     ts-jest: ^29.0.5
     ts-node: ^10.9.1
-    tslib: ^2.3.0
     typescript: ~4.9.4
   languageName: unknown
   linkType: soft
@@ -17689,13 +17687,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"moment@npm:^2.29.4":
-  version: 2.30.1
-  resolution: "moment@npm:2.30.1"
-  checksum: 859236bab1e88c3e5802afcf797fc801acdbd0ee509d34ea3df6eea21eb6bcc2abd4ae4e4e64aa7c986aa6cba563c6e62806218e6412a765010712e5fa121ba6
-  languageName: node
-  linkType: hard
-
 "motion-dom@npm:^11.18.1":
   version: 11.18.1
   resolution: "motion-dom@npm:11.18.1"
@@ -22293,7 +22284,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:2, tslib@npm:^2.0.0, tslib@npm:^2.0.1, tslib@npm:^2.1.0, tslib@npm:^2.3.0, tslib@npm:^2.3.1, tslib@npm:^2.4.0, tslib@npm:^2.4.1, tslib@npm:^2.5.0, tslib@npm:^2.6.0, tslib@npm:^2.6.2, tslib@npm:^2.7.0, tslib@npm:^2.8.0, tslib@npm:^2.8.1":
+"tslib@npm:2, tslib@npm:^2.0.0, tslib@npm:^2.0.1, tslib@npm:^2.1.0, tslib@npm:^2.3.1, tslib@npm:^2.4.0, tslib@npm:^2.4.1, tslib@npm:^2.5.0, tslib@npm:^2.6.0, tslib@npm:^2.6.2, tslib@npm:^2.7.0, tslib@npm:^2.8.0, tslib@npm:^2.8.1":
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
   checksum: e4aba30e632b8c8902b47587fd13345e2827fa639e7c3121074d5ee0880723282411a8838f830b55100cbe4517672f84a2472667d355b81e8af165a55dc6203a


### PR DESCRIPTION
**What changed? Why?**
This PR removes unused dependencies identified by `depcheck` and verified through comprehensive codebase search.

- Removed `moment` (2.30.1) - Not imported anywhere, "moment" only appears as English text
- Removed `tslib` - No imports found in the entire codebase

**Notes to reviewers**

**How has it been tested?**
- [x] `yarn build` passes successfully  
- [x] No TypeScript errors
- [x] Application builds correctly
Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources
