### PR TITLE
Nav + copy updates

### DIFF
--- a/apps/web/src/components/Layout/Navigation/Sidebar/Base-Sidebar.tsx
+++ b/apps/web/src/components/Layout/Navigation/Sidebar/Base-Sidebar.tsx
@@ -91,7 +91,10 @@ export function BaseNavigation({ isMobile = false }: { isMobile?: boolean }) {
   const isBuilders = buildersRoutes.some((route) => pathname.includes(route));
 
   const handleMenuItemClick = useCallback(
-    (route: { href: string; items?: { label: string; href: string }[] }) => {
+    (route: {
+      href: string;
+      items?: { label: string; href?: string; isSubheader?: boolean; isDivider?: boolean }[];
+    }) => {
       if (route.items && route.items.length > 0) {
         setIsExiting(true);
         // Small delay to allow exit animation to start
@@ -227,31 +230,57 @@ export function BaseNavigation({ isMobile = false }: { isMobile?: boolean }) {
 
                 <div className="pt-2">
                   {getCurrentMenuItems().map(
-                    (item: { href: string; label: string; icon?: string; newTab?: boolean }) => (
-                      <motion.div key={item.href} className="relative flex flex-col">
-                        <Link
-                          href={item.href}
-                          target={item.newTab ? '_blank' : '_self'}
-                          rel={item.newTab ? 'noopener noreferrer' : undefined}
-                          className={classNames(
-                            'flex w-full items-center rounded-lg p-2.5 leading-[114%] transition-colors duration-150',
-                            {
-                              'bg-base-gray-30 dark:bg-gray-90': isLinkActive({
-                                pathname,
-                                href: item.href,
-                              }),
-                              'text-black hover:bg-base-gray-30 dark:text-white dark:hover:bg-gray-90':
-                                !isLinkActive({
+                    (
+                      item: {
+                        href?: string;
+                        label: string;
+                        icon?: string;
+                        newTab?: boolean;
+                        isSubheader?: boolean;
+                        isDivider?: boolean;
+                      },
+                      index: number,
+                    ) => (
+                      <motion.div
+                        key={item.href ?? `${item.label}-${index}`}
+                        className="relative flex flex-col"
+                      >
+                        {item.isDivider ? (
+                          <div className="my-2 border-t border-base-gray-50 dark:border-gray-80" />
+                        ) : item.isSubheader ? (
+                          <div className="mb-1 mt-4 px-2.5 first:mt-0">
+                            <Text
+                              variant={TextVariant.CTALabelSm}
+                              className="text-xs font-medium uppercase tracking-wider text-base-gray-200 dark:text-gray-60"
+                            >
+                              {item.label}
+                            </Text>
+                          </div>
+                        ) : item.href ? (
+                          <Link
+                            href={item.href}
+                            target={item.newTab ? '_blank' : '_self'}
+                            rel={item.newTab ? 'noopener noreferrer' : undefined}
+                            className={classNames(
+                              'flex w-full items-center rounded-lg p-2.5 leading-[114%] transition-colors duration-150',
+                              {
+                                'bg-base-gray-30 dark:bg-gray-90': isLinkActive({
                                   pathname,
                                   href: item.href,
-                                }) && !isExiting,
-                              'text-black dark:text-white': isExiting,
-                            },
-                          )}
-                        >
-                          {item.icon && <Icon name={item.icon} className="mr-2 inline-block" />}
-                          <Text variant={TextVariant.CTALabelSm}>{item.label}</Text>
-                        </Link>
+                                }),
+                                'text-black hover:bg-base-gray-30 dark:text-white dark:hover:bg-gray-90':
+                                  !isLinkActive({
+                                    pathname,
+                                    href: item.href,
+                                  }) && !isExiting,
+                                'text-black dark:text-white': isExiting,
+                              },
+                            )}
+                          >
+                            {item.icon && <Icon name={item.icon} className="mr-2 inline-block" />}
+                            <Text variant={TextVariant.CTALabelSm}>{item.label}</Text>
+                          </Link>
+                        ) : null}
                       </motion.div>
                     ),
                   )}
@@ -260,37 +289,47 @@ export function BaseNavigation({ isMobile = false }: { isMobile?: boolean }) {
                 {/* appendix if so */}
                 {activeSubMenu &&
                   routes.find((route) => route.href === activeSubMenu)?.appendix && (
-                    <div className="border-t border-base-gray-50 pt-2">
+                    <div className="mt-2 border-t border-base-gray-50 pt-2 dark:border-gray-80">
                       {routes
                         .find((route) => route.href === activeSubMenu)
                         ?.appendix?.map(
-                          (appendixItem: { href: string; label: string; newTab?: boolean }) => (
-                            <motion.div key={appendixItem.href} className="relative flex flex-col">
-                              <Link
-                                href={appendixItem.href}
-                                target={appendixItem.newTab ? '_blank' : '_self'}
-                                rel={appendixItem.newTab ? 'noopener noreferrer' : undefined}
-                                className={classNames(
-                                  'group flex w-full items-center justify-between rounded-lg px-2.5 py-2 leading-[114%] transition-colors duration-150',
-                                  {
-                                    'bg-base-gray-30 dark:bg-gray-90': isLinkActive({
-                                      pathname,
-                                      href: appendixItem.href,
-                                    }),
-                                    'text-black hover:bg-base-gray-30 dark:text-white dark:hover:bg-gray-90':
-                                      !isLinkActive({
+                          (
+                            appendixItem: { href?: string; label: string; newTab?: boolean },
+                            index: number,
+                          ) => (
+                            <motion.div
+                              key={appendixItem.href ?? `appendix-${index}`}
+                              className="relative flex flex-col"
+                            >
+                              {appendixItem.href && (
+                                <Link
+                                  href={appendixItem.href}
+                                  target={appendixItem.newTab ? '_blank' : '_self'}
+                                  rel={appendixItem.newTab ? 'noopener noreferrer' : undefined}
+                                  className={classNames(
+                                    'group flex w-full items-center justify-between rounded-lg px-2.5 py-2 leading-[114%] transition-colors duration-150',
+                                    {
+                                      'bg-base-gray-30 dark:bg-gray-90': isLinkActive({
                                         pathname,
                                         href: appendixItem.href,
-                                      }) && !isExiting,
-                                    'text-black dark:text-white': isExiting,
-                                  },
-                                )}
-                              >
-                                <Text variant={TextVariant.CTALabelSm}>{appendixItem.label}</Text>
-                                <div className="text-[#B1B7C3] group-hover:text-black dark:text-[#1E2025] group-hover:dark:text-white">
-                                  <ExternalLinkIcon />
-                                </div>
-                              </Link>
+                                      }),
+                                      'text-black hover:bg-base-gray-30 dark:text-white dark:hover:bg-gray-90':
+                                        !isLinkActive({
+                                          pathname,
+                                          href: appendixItem.href,
+                                        }) && !isExiting,
+                                      'text-black dark:text-white': isExiting,
+                                    },
+                                  )}
+                                >
+                                  <Text variant={TextVariant.CTALabelSm}>{appendixItem.label}</Text>
+                                  {appendixItem.newTab && (
+                                    <div className="text-[#B1B7C3] group-hover:text-black dark:text-[#1E2025] group-hover:dark:text-white">
+                                      <ExternalLinkIcon />
+                                    </div>
+                                  )}
+                                </Link>
+                              )}
                             </motion.div>
                           ),
                         )}

--- a/apps/web/src/components/Layout/Navigation/navigation.ts
+++ b/apps/web/src/components/Layout/Navigation/navigation.ts
@@ -19,8 +19,10 @@ type BrandRoute = {
 type DefaultRouteItem = {
   icon?: string;
   label: string;
-  href: string;
+  href?: string;
   newTab?: boolean;
+  isSubheader?: boolean;
+  isDivider?: boolean;
 };
 
 type DefaultRoute = {
@@ -400,6 +402,12 @@ export const DEFAULT_ROUTES: DefaultRoute[] = [
         href: '/build',
       },
       {
+        icon: 'dashboard',
+        label: 'Dashboard',
+        href: 'https://base.dev/',
+        newTab: true,
+      },
+      {
         icon: 'wallet',
         label: 'Base Account',
         href: '/build/base-account',
@@ -421,24 +429,19 @@ export const DEFAULT_ROUTES: DefaultRoute[] = [
       },
       {
         icon: 'docs',
-        label: 'Base Docs',
-        href: 'https://docs.base.org/',
-        newTab: true,
-      },
-      {
-        icon: 'dashboard',
-        label: 'Grow your app',
-        href: 'https://base.dev/',
+        label: 'Spindl',
+        href: 'https://spindl.xyz/',
         newTab: true,
       },
     ],
     appendix: [
+      { label: 'Docs', href: 'https://docs.base.org/', newTab: true },
       { label: 'Status Page', href: 'https://status.base.org/', newTab: true },
-      { label: 'Bug Bounty', href: 'https://hackerone.com/coinbase', newTab: true },
       { label: 'Block Explorer', href: 'https://basescan.org/', newTab: true },
       { label: 'GitHub', href: 'https://github.com/base', newTab: true },
       { label: 'Engineering Blog', href: 'https://www.base.dev/blog', newTab: true },
       { label: 'Base Stats', href: '/stats', newTab: true },
+      { label: 'Bug Bounty', href: 'https://hackerone.com/coinbase', newTab: true },
     ],
   },
   {
@@ -459,6 +462,12 @@ export const DEFAULT_ROUTES: DefaultRoute[] = [
         href: '/resources',
       },
       {
+        icon: 'rocket',
+        label: 'Batches',
+        href: 'https://www.basebatches.xyz/',
+        newTab: true,
+      },
+      {
         icon: 'briefcase',
         label: 'Events',
         href: 'https://lu.ma/base-virtualevents?utm_source=dotorg&utm_medium=nav&period=past',
@@ -471,7 +480,7 @@ export const DEFAULT_ROUTES: DefaultRoute[] = [
     href: '/about',
     items: [
       {
-        icon: 'code',
+        icon: 'rocket',
         label: 'Vision',
         href: '/about/vision',
       },


### PR DESCRIPTION
**What changed? Why?**

**Base Build Menu:**
- Renamed "Grow your app" → "Dashboard" and moved it to position 2 (between "Base Build" and "Base Account")
- Added "Spindl" linking to https://spindl.xyz/ (positioned after "Appchains")
- Renamed "Base Docs" → "Docs" and moved it to the appendix section (below the divider)
- Moved "Bug Bounty" to the bottom of the appendix (below "Base Stats")

**Community Menu:**
- Added "Batches" linking to https://www.basebatches.xyz/ (positioned between "Resources" and "Events")

**About Menu:**
- Changed "Vision" icon from code icon to rocket icon

**Icon Updates:**
- Spindl: uses docs icon
- Batches: uses rocket icon
- Vision: uses rocket icon

**Technical:**
- Enhanced `Base-Sidebar.tsx` to support subheaders and dividers for future menu structures
- Updated TypeScript types to support optional hrefs, subheaders, and dividers
- All changes work seamlessly on both desktop and mobile

---

**Notes to reviewers**

**How has it been tested?**

Locally

Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources
