### PR TITLE
fix(docs): changed the Twitter link

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Base is a secure, low-cost, developer-friendly Ethereum L2 built to bring the ne
 [![Blog](https://img.shields.io/badge/blog-up-green)](https://base.mirror.xyz/)
 [![Docs](https://img.shields.io/badge/docs-up-green)](https://docs.base.org/)
 [![Discord](https://img.shields.io/discord/1067165013397213286?label=discord)](https://base.org/discord)
-[![Twitter Base](https://img.shields.io/twitter/follow/Base?style=social)](https://twitter.com/Base)
+[![Twitter Base](https://img.shields.io/twitter/follow/Base?style=social)](https://x.com/Base)
 
 <!-- Badge row 3 - detailed status -->
 


### PR DESCRIPTION
From November 10, the twitter domain will cease to operate

Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources
