### PR TITLE
Update Events link to BaseEvents and redirect /luma to BaseEvents

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -341,7 +341,7 @@ module.exports = MillionLint.next({
           },
           {
             source: '/luma',
-            destination: 'https://luma.com/BaseMeetups',
+            destination: 'https://luma.com/BaseEvents',
             permanent: true,
           },
           {

--- a/apps/web/src/components/Layout/Navigation/navigation.ts
+++ b/apps/web/src/components/Layout/Navigation/navigation.ts
@@ -465,7 +465,7 @@ export const DEFAULT_ROUTES: DefaultRoute[] = [
       {
         icon: 'briefcase',
         label: 'Events',
-        href: 'https://luma.com/BaseMeetups',
+        href: 'https://luma.com/BaseEvents',
         newTab: true,
       },
     ],


### PR DESCRIPTION
Updates the Events navigation link under Community tab from BaseMeetups to BaseEvents, and updates the /luma redirect to point to BaseEvents instead of BaseMeetups.