### PR TITLE
fix: Rename `BaseMeetups` to `BaseEvents` in links

### DIFF
--- a/apps/web/src/components/Layout/Footer/Footer.tsx
+++ b/apps/web/src/components/Layout/Footer/Footer.tsx
@@ -68,7 +68,7 @@ const LINK_SECTIONS = [
     title: 'Resources',
     links: [
       { label: 'Brand kit', href: 'https://www.base.org/brand', newTab: true },
-      { label: 'Events', href: 'https://lu.ma/BaseMeetups', newTab: true },
+      { label: 'Events', href: 'https://lu.ma/BaseEvents', newTab: true },
     ],
   },
   {

--- a/apps/web/src/components/base-org/root/Redesign/Section/BaseJoin/index.tsx
+++ b/apps/web/src/components/base-org/root/Redesign/Section/BaseJoin/index.tsx
@@ -68,6 +68,6 @@ const cards: CardProps[] = [
     image: card3.src,
     brightness: 1.9,
     contrast: 0.8,
-    href: 'https://lu.ma/BaseMeetups',
+    href: 'https://lu.ma/BaseEvents',
   },
 ];


### PR DESCRIPTION
**What changed? Why?**
Had some broken links, updated to correct meetups page.

**Notes to reviewers**

**How has it been tested?**
Locally

Have you tested the following pages?

BaseWeb
- [x] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources
