### PR TITLE
[BA-3331] Update Farcaster social link domain to farcaster.xyz

### DIFF
--- a/apps/web/src/utils/usernames.ts
+++ b/apps/web/src/utils/usernames.ts
@@ -138,7 +138,7 @@ export const formatSocialFieldUrl = (key: UsernameTextRecordKeys, handleOrUrl: s
     case UsernameTextRecordKeys.Twitter:
       return `https://x.com/${sanitizeHandle(handleOrUrl)}`;
     case UsernameTextRecordKeys.Farcaster:
-      return `https://warpcast.com/${sanitizeHandle(handleOrUrl)}`;
+      return `https://farcaster.xyz/${sanitizeHandle(handleOrUrl)}`;
     case UsernameTextRecordKeys.Github:
       return `https://github.com/${sanitizeHandle(handleOrUrl)}`;
     case UsernameTextRecordKeys.Url:
@@ -226,7 +226,7 @@ export const textRecordsKeysPlaceholderForDisplay = {
   [UsernameTextRecordKeys.Discord]: 'Username',
   [UsernameTextRecordKeys.Avatar]: 'Avatar',
   [UsernameTextRecordKeys.Frames]: 'Farcaster frame url',
-  [UsernameTextRecordKeys.Casts]: 'https://warpcast.com/...',
+  [UsernameTextRecordKeys.Casts]: 'https://farcaster.xyz/...',
 };
 
 export const textRecordsEngineersKeywords = [


### PR DESCRIPTION
**What changed? Why?**

Farcaster is transitioning from warpcast.com to farcaster.xyz as the canonical domain for user profiles. This change ensures that when users add their Farcaster handle to their Basename profile, the generated link points to the correct domain.

This change specifically targets user social profile links displayed on Basename profile pages. It does not affect:
- Platform navigation links (Base's official Farcaster links remain unchanged)
- Channel links or compose URLs
- Cast embed links

**Notes to reviewers**

The change is isolated to the `formatSocialFieldUrl` function which is used by the `UsernameProfileCard` component to render social links on user profiles

This only affects the Farcaster social field (UsernameTextRecordKeys.Farcaster) - other social platforms (Twitter, GitHub) remain unchanged.

The domain change maintains backward compatibility as farcaster.xyz properly redirects user profile URLs.

**How has it been tested?**

Tested it locally and verified the new link opens to the expected domain.

Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources
