### PR TITLE
docs: add ecosystem quick checklist to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,14 @@ base.org.
 
 ```
 yarn workspace @app/web dev
+
+### Quick checklist before opening a PR
+
+- `yarn` at the repo root has completed successfully.
+- `yarn workspace @app/web dev` shows your project on the Ecosystem page.
+- `yarn workspace @app/web build` succeeds without errors.
+- The `ecosystem.json` entry points to a Base-specific URL and uses a 192x192 logo from `apps/web/public/images/partners/`.
+
 ```
 
 6. Make sure the build works properly before creating the PR:


### PR DESCRIPTION
Summary
- Add a quick checklist for projects updating the Base Ecosystem page
- Highlight the key commands and assets that should be verified before opening a PR

Rationale
- Makes it easier for builders to confirm their ecosystem entry and assets are correctly configured before submitting
