### PR TITLE
Harden basenames metadata token validation

### DIFF
--- a/apps/web/app/(basenames)/api/basenames/metadata/[tokenId]/route.ts
+++ b/apps/web/app/(basenames)/api/basenames/metadata/[tokenId]/route.ts
@@ -27,6 +27,10 @@ export async function GET(
   if (!formattedTokenId) {
     return NextResponse.json({ error: '400: tokenId is missing' }, { status: 400 });
   }
+  
+  if (!/^[0-9]+$/.test(formattedTokenId)) {
+      return NextResponse.json({ error: '400: tokenId must be a positive integer' }, { status: 400 });
+  }
 
   const chainId = getChain(request);
   if (!chainId) {


### PR DESCRIPTION
## Summary

  - Validate basenames metadata tokenId to require a positive integer.
  - Return a clear 400 error for malformed tokenIds instead of throwing during BigInt conversion.

  ## Changes

  - Add numeric guard for tokenId in apps/web/app/(basenames)/api/basenames/metadata/[tokenId]/route.ts.

  ## Motivation

  Prevent unexpected 500s from invalid tokenIds and give clients actionable errors.

  ## Risk & Impact

  - Risk level: Low
  - Impact: Requests with non-numeric tokenIds now return 400; valid numeric tokenIds behave the same.

  ## Testing

  - [ ] Call GET /api/basenames/metadata/foo and expect 400.
  - [ ] Call with a numeric tokenId and confirm normal metadata response.

