### PR TITLE
fix: update the Farcaster links to the latest version

### DIFF
--- a/apps/web/src/utils/socialPlatforms.ts
+++ b/apps/web/src/utils/socialPlatforms.ts
@@ -52,7 +52,7 @@ export const socialPlatformShareLinkFunction: SocialPlatformShareLinkFunction = 
       text: text,
     };
 
-    return urlWithQueryParams('https://warpcast.com/~/compose', shareParams);
+    return urlWithQueryParams('https://farcaster.xyz/~/compose', shareParams);
   },
 };
 


### PR DESCRIPTION
**What changed? Why?**
- update the Farcaster links to the latest version
**Notes to reviewers**
- update the Farcaster links to the latest version
**How has it been tested?**

Have you tested the following pages?

BaseWeb
- [x] base.org
- [x] base.org/names
- [x] base.org/builders
- [x] base.org/ecosystem
- [x] base.org/name/jesse
- [x] base.org/manage-names
- [x] base.org/resources
