### PR TITLE
chore(BA:35322): Add availability check to claims search

### DIFF
--- a/apps/web/app/(basenames)/names/page.tsx
+++ b/apps/web/app/(basenames)/names/page.tsx
@@ -5,6 +5,9 @@ import RegistrationFAQ from 'apps/web/src/components/Basenames/RegistrationFaq';
 import RegistrationFlow from 'apps/web/src/components/Basenames/RegistrationFlow';
 import RegistrationValueProp from 'apps/web/src/components/Basenames/RegistrationValueProp';
 import type { Metadata } from 'next';
+import { redirect } from 'next/navigation';
+import { base } from 'viem/chains';
+import { getBasenameAvailable } from 'apps/web/src/utils/usernames';
 import basenameCover from './basename_cover.png';
 
 export const metadata: Metadata = {
@@ -23,10 +26,17 @@ export const metadata: Metadata = {
   },
 };
 
-type PageProps = { searchParams?: Promise<{ code?: string }> };
+type PageProps = { searchParams?: Promise<{ code?: string; claim?: string }> };
 export default async function Page(props: PageProps) {
   const searchParams = await props.searchParams;
   const code = searchParams?.code;
+  const claim = searchParams?.claim;
+
+  if (claim) {
+    // Always check on Base mainnet for shared claim links since users won't have a wallet connected yet
+    const isAvailable = await getBasenameAvailable(claim, base).catch(() => false);
+    if (!isAvailable) redirect('/names');
+  }
 
   return (
     <ErrorsProvider context="registration">


### PR DESCRIPTION
**What changed? Why?**

We now redirect back to `/names` when the searched name is not available. This prevents users entering a broken RegistrationFlow for an unavailable name. 

**Notes to reviewers**

**How has it been tested?**

Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources
