### PR TITLE
feat(nav): Add Base App Help link to About menu

### DIFF
--- a/apps/web/src/components/Layout/Navigation/navigation.ts
+++ b/apps/web/src/components/Layout/Navigation/navigation.ts
@@ -495,6 +495,12 @@ export const DEFAULT_ROUTES: DefaultRoute[] = [
         label: 'Jobs',
         href: '/jobs',
       },
+      {
+        icon: 'docs',
+        label: 'Base App Help',
+        href: 'https://help.coinbase.com/en/base',
+        newTab: true,
+      },
     ],
   },
 ];


### PR DESCRIPTION
## Summary
Adds a new "Base App Help" link under the About navigation menu that links to the Coinbase Help Center for Base.

## Changes
- Added new navigation item in `apps/web/src/components/Layout/Navigation/navigation.ts`
- Link: https://help.coinbase.com/en/base
- Opens in a new tab

## Linear Ticket
[TBAFIN-3445](https://linear.app/coinbase/issue/TBAFIN-3445/add-url-to-baseorg-docs-that-link-out-to-the-help-center-on)

## Testing
- Verified locally on localhost:3000
- Confirmed link appears in the About dropdown menu