### PR TITLE
Add crypto-sentiment-api to ecosystem

### DIFF
--- a/apps/web/src/data/ecosystem/crypto-sentiment-api
+++ b/apps/web/src/data/ecosystem/crypto-sentiment-api
@@ -5,6 +5,7 @@
   "tags": ["x402", "API", "Trading", "Sentiment", "AI Agents"],
   "logo": "https://raw.githubusercontent.com/lobsterbar2027-boop/crypto-sentiment-api/main/assets/logo.png",
   "website": "api.genvox.io",
+   "x402scan": "https://www.x402scan.com/server/5aec2eb2-473d-43e1-b9a6-6fed42b04212",
   "twitter": "https://x.com/BreakTheCubicle",
   "github": "https://github.com/lobsterbar2027-boop/crypto-sentiment-api"
 }


### PR DESCRIPTION
## Description

Adding **Crypto Sentiment API (GenVox)** to the Base ecosystem page.

## Project Information

**Category:** DeFi / Developer Tools

**What it does:**
Real-time crypto sentiment analysis API for AI trading bots. Analyzes Reddit social data to return BUY/SELL/NEUTRAL signals with confidence scores.

**Key Features:**
- Built on Base Network (L2)
- x402 protocol for payments ($0.03 USDC per query)
- 10+ supported cryptocurrencies (BTC, ETH, SOL, DOGE, ADA, XRP, DOT, MATIC, LINK, UNI)
- Sub-200ms response times
- No API keys or subscriptions required

**Status:**
✅ Live on mainnet (Base)
✅ x402 integration working
✅ Listed on x402scan: https://www.x402scan.com/server/5aec2eb2-473d-43e1-b9a6-6fed42b04212

## Resources

- **Website:** https://genvox.io
- **GitHub:** https://github.com/lobsterbar2027-boop/crypto-sentiment-api


## Use Cases

- Trading bots making buy/sell decisions based on Reddit sentiment
- Portfolio managers rebalancing based on sentiment shifts
- Alert systems for extreme sentiment events
- Research on sentiment-price correlation

Ready for review! 