### PR TITLE
chore(BA-2134): Use full name for primary name set

### DIFF
--- a/apps/web/src/hooks/useRegisterNameCallback.ts
+++ b/apps/web/src/hooks/useRegisterNameCallback.ts
@@ -200,7 +200,7 @@ export function useRegisterNameCallback(
                     abi: L2ReverseRegistrarAbi,
                     address: USERNAME_L2_REVERSE_REGISTRAR_ADDRESSES[basenameChain.id],
                     functionName: 'setName',
-                    args: [normalizedName],
+                    args: [formatBaseEthDomain(name, basenameChain.id)],
                   },
                 ]
               : []),


### PR DESCRIPTION
**What changed? Why?**
We need to use the full basename when setting primary records on the L2ReverseRegistrar. 

**Notes to reviewers**

**How has it been tested?**

Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources
