### PR TITLE
docs: Add JSON syntax warning to Ecosystem contribution guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,11 @@ If you're a builder who wants to add or update your project on the [Base Ecosyst
 3. Update the `ecosystem.json` file in `apps/web/src/data/` with your project's details :
 
    ```json
+
+   > **Important:** Please ensure your JSON is valid before committing!
+> A single missing comma or trailing comma will fail the build.
+> We recommend running `yarn lint` locally or checking your syntax with a tool like [JSONLint](https://jsonlint.com/).
+
    {
      "name": "Your Project Name",
      "description": "A brief description (less than 200 characters)",


### PR DESCRIPTION
This Commit adds a crucial warning to the **Updating the Base Ecosystem Page** section.

**What changed? Why?**

**Notes to reviewers**

**How has it been tested?**

Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources
