### PR TITLE
fix: add missing period in consent text

### DIFF
--- a/apps/web/app/(base-org-dark)/(builders)/build/onchainkit/FeaturesSection.tsx
+++ b/apps/web/app/(base-org-dark)/(builders)/build/onchainkit/FeaturesSection.tsx
@@ -137,7 +137,7 @@ const baseAccountFeatures = [
     colorClass: 'text-[#7575FF]',
     title: 'Reduce friction',
     description:
-      'Request user consent to provide details like name, address, or email to streamline onchain UX flows',
+      'Request user consent to provide details like name, address, or email to streamline onchain UX flows.',
   },
   {
     colorClass: 'text-[#B8A581]',


### PR DESCRIPTION
Adds a missing period at the end of the consent sentence. No wording changes.

