### PR TITLE
fix(middleware): avoid double slash in /flashblocks redirect

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -14,7 +14,7 @@ export function middleware(req: NextRequest) {
   if (url.pathname.startsWith('/flashblocks')) {
     const subPath = url.pathname.replace('/flashblocks', '');
     url.host = 'flashblocks.base.org';
-    url.pathname = `/${subPath}`;
+    url.pathname = subPath.startsWith('/') ? subPath : `/${subPath}`;
     url.port = '443';
 
     return NextResponse.redirect(url);


### PR DESCRIPTION
**What changed? Why?**

Fixes /flashblocks redirect path construction to avoid producing URLs with double slashes.

**Notes to reviewers**

Previously, redirecting from /flashblocks/* could set url.pathname to `//...` because subPath already begins with `/`.
This change normalizes the pathname before redirecting.

**How has it been tested?**

Manually. 

Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources
