### PR TITLE
ci: upgrade actions to v4 and add CI badge

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -17,10 +17,10 @@ jobs:
         node-version: [18.x]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -19,9 +19,9 @@ jobs:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 Base is a secure, low-cost, developer-friendly Ethereum L2 built to bring the next billion users onchain. It's built on Optimism's open-source [OP Stack](https://stack.optimism.io/).
 
+![Node.js CI](https://github.com/AdekunleBamz/web/actions/workflows/node.js.yml/badge.svg)
+
 <!-- Badge row 1 - status -->
 
 [![GitHub contributors](https://img.shields.io/github/contributors/base/web)](https://github.com/base/web/graphs/contributors)


### PR DESCRIPTION
## Summary
Upgraded deprecated GitHub Actions and improved documentation visibility.

## Changes
- **node.js.yml**: Upgraded `actions/checkout` and `actions/setup-node` from v3 to v4
- **e2e-tests.yml**: Upgraded `actions/checkout` and `actions/setup-node` from v3 to v4
- **README.md**: Added Node.js CI workflow status badge

## Why
- v3 actions are deprecated and will stop working
- v4 includes performance improvements and Node.js 20 support
- CI badge provides instant visibility of build status