### PR TITLE
Disable code snippet ligatures

### DIFF
--- a/apps/web/src/components/Builders/Shared/CodeSnippet.tsx
+++ b/apps/web/src/components/Builders/Shared/CodeSnippet.tsx
@@ -51,7 +51,7 @@ export function CodeSnippet({ code }: { code: string }) {
 
   return (
     <div
-      className="code-snippet h-full overflow-auto rounded-lg transition-colors"
+      className="code-snippet h-full overflow-auto rounded-lg transition-colors ligatures-none"
       // eslint-disable-next-line react/no-danger -- necessary for shiki
       dangerouslySetInnerHTML={htmlContent}
     />

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -667,6 +667,9 @@ module.exports = {
         '.scrollbar-gutter-stable': {
           'scrollbar-gutter': 'stable',
         },
+        '.ligatures-none': {
+          'font-variant-ligatures': 'none',
+        },
       });
     },
   ],


### PR DESCRIPTION
**What changed? Why?**
Added `ligatures-none` Tailwind utility and use it in Builder's `<CodeSnippet />`

| Before | After |
|--------|--------|
| <img width="2296" height="1606" alt="image" src="https://github.com/user-attachments/assets/5a65f6ff-b82b-434b-8bb4-0c2f7dcff0f7" /> | <img width="2302" height="1604" alt="image" src="https://github.com/user-attachments/assets/b4385197-8d95-4b48-bf1c-718337341f70" /> | 

**Notes to reviewers**

**How has it been tested?**

Have you tested the following pages?

BaseWeb
- [ ] base.org
- [ ] base.org/names
- [x] base.org/builders
- [ ] base.org/ecosystem
- [ ] base.org/name/jesse
- [ ] base.org/manage-names
- [ ] base.org/resources
