### PR TITLE
chore: update versions to 24.x to match prod deploy node ver

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/hydrogen
+v24.13.0

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "next-transpile-modules": "Next compatibility"
   },
   "engines": {
-    "node": "20.x"
+    "node": "24.x"
   },
   "packageManager": "yarn@3.5.0",
   "dependencies": {


### PR DESCRIPTION
**What changed? Why?**

update to 24.x

**Notes to reviewers**

**How has it been tested?**

Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources
