### PR TITLE
fix: validate address param in getUsernames endpoint

### DIFF
--- a/apps/web/app/(basenames)/api/basenames/getUsernames/route.ts
+++ b/apps/web/app/(basenames)/api/basenames/getUsernames/route.ts
@@ -1,12 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { isAddress } from 'viem';
 
 import type { ManagedAddressesResponse } from 'apps/web/src/types/ManagedAddresses';
 import { cdpBaseUri } from 'apps/web/src/cdp/constants';
 
 export async function GET(request: NextRequest) {
   const address = request.nextUrl.searchParams.get('address');
-  if (!address) {
-    return NextResponse.json({ error: 'No address provided' }, { status: 400 });
+  if (!address || !isAddress(address)) {
+    return NextResponse.json({ error: 'Invalid address provided' }, { status: 400 });
   }
 
   const network = request.nextUrl.searchParams.get('network') ?? 'base-mainnet';
@@ -28,6 +29,10 @@ export async function GET(request: NextRequest) {
       'Content-Type': 'application/json',
     },
   });
+
+  if (!response.ok) {
+    return NextResponse.json({ error: 'Failed to fetch usernames' }, { status: response.status });
+  }
 
   const data = (await response.json()) as ManagedAddressesResponse;
 


### PR DESCRIPTION
**What changed? Why?**

Added input validation for the \`address\` query parameter in the \`/api/basenames/getUsernames\` endpoint to prevent path traversal attacks. The endpoint was receiving malformed requests with values like \`..%2Faddresses%3F\` (decoded: \`../addresses?\`) which caused 500 errors when the CDP API rejected the malformed URL.

Changes:
- Validate \`address\` is a valid Ethereum address using viem's \`isAddress()\`
- Return 400 for invalid addresses instead of passing them to the CDP API
- Add error handling for CDP API failures (check \`response.ok\`)

**Ticket ID/URL**

N/A

**Notes to reviewers**

This fixes 500 errors caused by malicious external requests attempting path traversal. Legitimate internal usage from \`useNameList()\` hook uses wallet addresses from \`useAccount()\` which are always valid.

**How has it been tested?**

Have you tested the following pages?

BaseWeb
- [] base.org
- [x] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources
