### PR TITLE
Update E2Ereadme.md

### DIFF
--- a/apps/web/e2e/E2Ereadme.md
+++ b/apps/web/e2e/E2Ereadme.md
@@ -12,7 +12,11 @@ This folder contains Playwright tests for the Base Web project against a local N
 
 ## Prerequisites
 
-run yarn add -D @playwright/test @coinbase/onchaintestkit
+Run:
+
+```bash
+yarn add -D @playwright/test @coinbase/onchaintestkit
+```
 
 > The scripts have been tested on macOS and Linux. Windows users should run the commands inside WSL 2.
 


### PR DESCRIPTION
**What changed? Why?**
Before the change, the line was `run yarn add -D @playwright/test @coinbase/onchaintestkit`. When I copied it and ran it in the terminal, it gave an error. So, for clarity:
- I separated “Run:” and the command
- I wrapped the command in a syntax-highlighted code block (```bash)

Now the copy button copies the working command.

**Notes to reviewers**

**How has it been tested?**
Copied the command, it works in the terminal.

Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources
