### PR TITLE
fix(package.json): correct repository URL (remove extra colon)

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@base-org/base-web",
   "version": "1.0.0",
   "description": "Base web monorepo",
-  "repository": "git@github.com::base/base-web.git",
+  "repository": "git@github.com:base-org/base-web.git",
   "license": "Apache-2.0",
   "scripts": {
     "build": "yarn workspaces foreach --exclude @app/bridge run build",


### PR DESCRIPTION
**What changed? Why?**

**Notes to reviewers**

**How has it been tested?**

Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources
