### PR TITLE
fix: typo in the code

### DIFF
--- a/apps/web/src/utils/bugsnag.ts
+++ b/apps/web/src/utils/bugsnag.ts
@@ -41,7 +41,7 @@ async function inititializeBugsnag() {
 
 export async function bugsnagNotify(error: Error | string, onError?: OnErrorCallback) {
   if (!BugsnagClient) {
-    await inititializeBugsnag();
+    await initializeBugsnag();
   }
 
   if (!BugsnagClient) {


### PR DESCRIPTION
**What changed? Why?**
Was: await inititializeBugsnag();
Became: await initializeBugsnag();

**Notes to reviewers**

**How has it been tested?**

Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources
