### PR TITLE
fix: dependency cache for `yarn`

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'npm'
+          cache: 'yarn'
       - name: Install dependencies
         run: yarn
       - name: Lint


### PR DESCRIPTION
**What changed? Why?**
Changed cache from `npm` to `yarn` in [node.js.yml](https://github.com/base/web/blob/master/.github/workflows/node.js.yml)

**Notes to reviewers**
N/A

**How has it been tested?**
The project uses `yarn` instead of `npm`.
This is specified in `package.json`.

Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources
