### PR TITLE
Fix basename domain fallback to avoid double-dot domains

### DIFF
--- a/apps/web/src/utils/usernames.ts
+++ b/apps/web/src/utils/usernames.ts
@@ -350,7 +350,8 @@ export const USERNAME_DOMAINS: Record<number, string> = {
 };
 
 export const formatBaseEthDomain = (name: string, chainId: number): Basename => {
-  return `${name}.${USERNAME_DOMAINS[chainId] ?? '.base.eth'}`.toLocaleLowerCase() as Basename;
+  const domain = USERNAME_DOMAINS[chainId] ?? 'base.eth';
+  return `${name}.${domain}`.toLocaleLowerCase() as Basename;
 };
 
 export const convertChainIdToCoinType = (chainId: number): string => {


### PR DESCRIPTION
**What changed? Why?**

- Use base.eth (no leading dot) as the fallback domain when chainId is not present in USERNAME_DOMAINS.

**Notes to reviewers**

- The previous fallback used a leading dot, which could generate an invalid/incorrect basename string with a double dot and potentialy break ENS formatting.

**How has it been tested?**

- Manual review (string output formatting) for known chainIds and unknown chainIds."

Have you tested the following pages?

BaseWeb
- [] base.org
- [] base.org/names
- [] base.org/builders
- [] base.org/ecosystem
- [] base.org/name/jesse
- [] base.org/manage-names
- [] base.org/resources
