### PR TITLE
fix(sybil-resistance): remove `nx` option to ensure claim updates in KV

### DIFF
--- a/apps/web/src/utils/proofs/sybil_resistance.ts
+++ b/apps/web/src/utils/proofs/sybil_resistance.ts
@@ -216,7 +216,7 @@ export async function sybilResistantUsernameSigning(
     const claim: PreviousClaim = { address, signedMessage };
     previousClaims[discountType] = claim;
 
-    await kv.set<PreviousClaims>(kvKey, previousClaims, { nx: true, ex: parseInt(EXPIRY) });
+    await kv.set<PreviousClaims>(kvKey, previousClaims, { ex: parseInt(EXPIRY) });
 
     return {
       signedMessage: claim.signedMessage,


### PR DESCRIPTION
## Problem
The `kv.set()` call uses `{ nx: true }`, which prevents updating existing records. When a key already exists in KV but the current `discountType` is not in `previousClaims`, the data isn't saved - yet the API still returns a `signedMessage` as if the claim was successfully stored.

This creates inconsistency between KV state and API response, breaking the anti-sybil protection mechanism that prevents duplicate signature issuance.

## Solution
Remove `nx: true` from `kv.set(`) options to ensure the record is always updated.

## Impact
- Existing records properly update when a new `discountType` is added
- Duplicate claims for the same `discountType` are still rejected (upstream logic unchanged)
- TTL (expiry) functionality remains intact
