### PR TITLE
chore: remove duplicated marquee keyframes

### DIFF
--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -564,14 +564,6 @@ module.exports = {
           '0%': { transform: 'translateX(0)' },
           '100%': { transform: 'translateX(-50%)' },
         },
-        marquee: {
-          from: { transform: 'translateX(0)' },
-          to: { transform: 'translateX(calc(-100% - var(--gap)))' },
-        },
-        'marquee-vertical': {
-          from: { transform: 'translateY(0)' },
-          to: { transform: 'translateY(calc(-100% - var(--gap)))' },
-        },
 
         progress: {
           '0%': { width: '0%' },


### PR DESCRIPTION
Removes duplicated marquee and marquee-vertical keyframes in the Tailwind config. The earlier definitions were overridden by the later ones, so removing them does not change runtime behavior.